### PR TITLE
revamp PoS/PoW material

### DIFF
--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -4,7 +4,7 @@ Decred has two methods of transaction verification proof-of-work (PoW) and proof
 
 ---
 
-## **1. <i class="fa fa-fire"></i> Proof-of-work Mining**
+## **1. <i class="fa fa-fire"></i> [Proof-of-work (PoW) Mining](proof-of-work.md)**
 
 Proof-of-work mining, more commonly referred to as PoW mining, is the activity of committing your computer’s hardware and resources to process network transactions and build the blocks that make up the blockchain in the Decred network. Each time a block is created (by a miner), about 30 new Decred coins are made. These coins are then split up as follows:
 
@@ -18,59 +18,8 @@ You will, on average, receive a reward that is roughly proportional to the hashr
 
 ---
 
-### 1.1 <i class="fa fa-life-ring"></i> Pool Mining
+## **2. <i class="fa fa-ticket"></i> [Proof-of-stake (PoS) Mining](proof-of-stake.md)**
 
-If you have a small hashrate compared to the hashrate of the network, pool mining may be your best option. When you mine in a pool, your miner’s hashrate is combined with all the other pool miners’ hashrates to look for the correct solution for a block. You will receive a reward based on the amount of work your miner performs in the pool.
-
-These are the community mining pools:
-
-* http://coinmine.pl/dcr
-* https://dcr.maxminers.net
-* https://dcr.suprnova.cc
-* https://pool.mn/dcr
-* http://yiimp.ccminer.org
-* https://zpool.ca
-
----
-
-#### 1.1.1 cgminer
-
-----
-
-##### 1.1.1.1 <i class="fa fa-windows"></i> [Windows](proof-of-work/pool-mining/cgminer/windows.md)
-
----
-
-##### 1.1.1.2 <i class="fa fa-linux"></i> [Linux](proof-of-work/pool-mining/cgminer/linux.md)
-
----
-
-### 1.2 <i class="fa fa-male"></i> Solo Mining
-
----
-
-#### 1.2.1 cgminer
-
----
-
-##### 1.2.1.1 <i class="fa fa-windows"></i> [Windows](proof-of-work/solo-mining/cgminer/windows.md)
-
----
-
-##### 1.2.2.2 <i class="fa fa-linux"></i> [Linux](proof-of-work/solo-mining/cgminer/linux.md)
-
----
-
-## **2. <i class="fa fa-ticket"></i> Proof-of-stake Mining**
-
-Proof of Stake mining is the second method of transaction verification in Decred. It is computationally cheap (you can run a full PoS node on a Raspberry Pi) but it requires you to already have some DCR in your wallet. In the Decred network, PoW miners solve blocks then turn those blocks over to PoS miners to vote on them. PoS miners buy tickets for the stake pool via their wallets. When a block is completed, 5 tickets are chosen at random from the stake pool to vote on the block. If at least 3 votes are ‘Yes' then the block is validated, included in the block chain and both PoW and PoS miners are paid. If the vote fails, the block is discarded and the transactions return to be included in another block. The PoW miners are not paid, however the PoS miners are.
+Proof of Stake mining is the second method of block verification in Decred. It is computationally cheap but it requires you to already have some DCR in your wallet. In the Decred network, PoW miners solve blocks then turn those blocks over to PoS miners to vote on them. When a block is completed, 5 tickets are chosen at random from the stake pool to vote on the block. If at least 3 votes are ‘Yes' then the block is validated, included in the block chain and both PoW and PoS miners are paid. If the vote fails, the block is discarded and the transactions return to be included in another block. The PoW miners are not paid, however the PoS miners are.
 
 This is to incentivize PoW miners to mine according to the wishes of PoS miners. For example, if the rules of the network change in the future any PoW miners who don't follow them will not be paid. It also helps stop large mining pools getting too much influence over the network. In other cryptocurrencies that don't use PoS, the large groups of PoW miners who effectively control the network can collude to block transactions, stop network changes or even force faked transactions (although this would take a huge amount of resources). Collusion between PoW and PoS miners is not possible as tickets are not chosen until the time of the vote. Collusion between PoS miners is likewise remote as the ticket pool is kept at around 40,960 active tickets at any time. The chance of three tickets belonging to the same individual or group being chosen for the same block is very small. Even if this did happen every transaction is validated at least twice so the chance of anyone manipulating the blockchain is effectively zero.
-
----
-
-### 2.1 <i class="fa fa-life-ring"></i> [Pool Mining](proof-of-stake/pool-mining.md)
-
----
-
-### 2.2 <i class="fa fa-male"></i> [Solo Mining](proof-of-stake/solo-mining.md)

--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -1,12 +1,17 @@
 # **<i class="fa fa-info-circle"></i> Overview**
 
-Decred has two methods of transaction verification proof-of-work (PoW) and proof-of-stake (PoS).
+Decred has two methods of transaction verification proof-of-work (PoW) and
+proof-of-stake (PoS).
 
 ---
 
 ## **1. <i class="fa fa-fire"></i> [Proof-of-work (PoW) Mining](proof-of-work.md)**
 
-Proof-of-work mining, more commonly referred to as PoW mining, is the activity of committing your computer’s hardware and resources to process network transactions and build the blocks that make up the blockchain in the Decred network. Each time a block is created (by a miner), about 30 new Decred coins are made. These coins are then split up as follows:
+Proof-of-work mining, more commonly referred to as PoW mining, is the activity
+of committing your computer’s hardware and resources to process network
+transactions and build the blocks that make up the blockchain in the Decred
+network. Each time a block is created (by a miner), about 30 new Decred coins
+are made. These coins are then split up as follows:
 
 Subsidy | Party
 ---     | ---
@@ -14,12 +19,38 @@ Subsidy | Party
 `30%`   | PoS Voters
 `10%`   | Decred development subsidy
 
-You will, on average, receive a reward that is roughly proportional to the hashrate of your miner and the overall hashrate of the network when you commit your computer to PoW mining. To get started, you must have a computer with a video card. Most video cards can be used for mining (including the "mobile" types found in some laptops). In general, higher end video cards perform at higher hashrates and therefore receive higher rewards.
+You will, on average, receive a reward that is roughly proportional to the
+hashrate of your miner and the overall hashrate of the network when you commit
+your computer to PoW mining. To get started, you must have a computer with a
+video card. Most video cards can be used for mining (including the "mobile"
+types found in some laptops). In general, higher end video cards perform at
+higher hashrates and therefore receive higher rewards.
 
 ---
 
 ## **2. <i class="fa fa-ticket"></i> [Proof-of-stake (PoS) Mining](proof-of-stake.md)**
 
-Proof of Stake mining is the second method of block verification in Decred. It is computationally cheap but it requires you to already have some DCR in your wallet. In the Decred network, PoW miners solve blocks then turn those blocks over to PoS miners to vote on them. When a block is completed, 5 tickets are chosen at random from the stake pool to vote on the block. If at least 3 votes are ‘Yes' then the block is validated, included in the block chain and both PoW and PoS miners are paid. If the vote fails, the block is discarded and the transactions return to be included in another block. The PoW miners are not paid, however the PoS miners are.
+Proof of Stake mining is the second method of block verification in Decred. It
+is computationally cheap but it requires you to already have some DCR in your
+wallet. In the Decred network, PoW miners solve blocks then turn those blocks
+over to PoS miners to vote on them. When a block is completed, 5 tickets are
+chosen at random from the stake pool to vote on the block. If at least 3 votes
+are ‘Yes' then the block is validated, included in the block chain and both
+PoW and PoS miners are paid. If the vote fails, the block is discarded and the
+transactions return to be included in another block. The PoW miners are not
+paid, however the PoS miners are.
 
-This is to incentivize PoW miners to mine according to the wishes of PoS miners. For example, if the rules of the network change in the future any PoW miners who don't follow them will not be paid. It also helps stop large mining pools getting too much influence over the network. In other cryptocurrencies that don't use PoS, the large groups of PoW miners who effectively control the network can collude to block transactions, stop network changes or even force faked transactions (although this would take a huge amount of resources). Collusion between PoW and PoS miners is not possible as tickets are not chosen until the time of the vote. Collusion between PoS miners is likewise remote as the ticket pool is kept at around 40,960 active tickets at any time. The chance of three tickets belonging to the same individual or group being chosen for the same block is very small. Even if this did happen every transaction is validated at least twice so the chance of anyone manipulating the blockchain is effectively zero.
+This is to incentivize PoW miners to mine according to the wishes of PoS
+miners. For example, if the rules of the network change in the future any
+PoW miners who don't follow them will not be paid. It also helps stop large
+mining pools getting too much influence over the network. In
+cryptocurrencies that don't use PoS, the large groups of PoW miners who
+effectively control the network can collude to block transactions, stop network
+changes or even force faked transactions (although this would take a huge
+amount of resources). Collusion between PoW and PoS miners is not possible as
+tickets are not chosen until the time of the vote. Collusion between PoS miners
+is likewise remote as the ticket pool is kept at around 40,960 active tickets
+at any time. The chance of three tickets belonging to the same individual or
+group being chosen for the same block is very small. Even if this did happen
+every transaction is validated at least twice so the chance of anyone
+manipulating the blockchain is effectively zero.

--- a/docs/mining/proof-of-stake.md
+++ b/docs/mining/proof-of-stake.md
@@ -1,0 +1,129 @@
+# ** Proof-of-stake (PoS) Mining**
+
+---
+
+## ** Solo Mining or Pool Mining **
+
+> <i class="fa fa-male"></i> Solo Mining
+
+<i class="fa fa-exclamation-triangle"></i> In order to successfully participate in PoS, you need to ensure that your wallet is online 24/7. This is because your ticket may be called on to vote at any time and if your wallet is unable to respond you will lose the vote reward.  The amount of your ticket purchase will be returned to you, however, ticket purchase fees will not be returned.
+
+> <i class="fa fa-users"></i> Pool Mining
+
+Using a stake pool is beneficial because the servers are geographically distributed and redundant which vastly increases the odds that your vote will always be cast even in the event of a network or server outage.  However, stake pools charge a fee in order to pay for server costs.
+
+---
+
+## **<i class="fa fa-ticket"></i> Purchasing tickets**
+
+To participate in PoS mining, you will first need to have followed the [Getting Started](/getting-started/overview.md) guide, [Obtain DCR](/getting-started/obtaining-dcr.md) guide, and have unlocked your wallet. 
+
+> Sign up at a stake pool (Pool Mining)
+
+<i class="fa fa-times"></i>** Coming Soon ** No public stake pools have launched at this time. An announcement will be made when they are available and this documentation will be updated. You may track progress on the [<i class="fa fa-comments"></i> stake pool forum thread](https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/).
+
+> Manual ticket purchasing (Overview)
+
+First, obtain the current ticket price by visiting a site such as [dcrstats.com](https://dcrstats.com), [stats.decred.org](https://stats.decred.org), or see the difficulty field from the following dcrctl command:
+
+```no-highlight
+dcrctl --wallet getstakeinfo
+{
+  "poolsize": 42670,
+  "difficulty": 22.07045882,
+  "allmempooltix": 0,
+  "ownmempooltix": 0,
+  "immature": 0,
+  "live": 0,
+  "proportionlive": 0,
+  "voted": 0,
+  "totalsubsidy": 0,
+  "missed": 0,
+  "proportionmissed": 0,
+  "revoked": 0
+}
+```
+
+Now purchase your ticket(s) via dcrctl.  The syntax for the command is:
+
+```no-highlight
+dcrctl --wallet help purchaseticket
+purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
+
+Purchase ticket using available funds.
+
+Arguments:
+1. fromaccount   (string, required)             The account to use for purchase (default="default")
+2. spendlimit    (numeric, required)            Limit on the amount to spend on ticket
+3. minconf       (numeric, optional, default=1) Minimum number of block confirmations required
+4. ticketaddress (string, optional)             Override the ticket address to which voting rights are given
+5. numtickets    (numeric, optional)            The number of tickets to purchase
+6. pooladdress   (string, optional)             The address to pay stake pool fees to
+7. poolfees      (numeric, optional)            The amount of fees to pay to the stake pool
+8. expiry        (numeric, optional)            Height at which the purchase tickets expire
+9. comment       (string, optional)             Unused
+
+Result:
+"value" (string) Hash of the resulting ticket
+```
+
+> Manual ticket purchasing example (Solo Mining)
+
+```no-highlight
+dcrctl --wallet purchaseticket "default" 23 1 "" 1 "" "" 1 "this purchases one ticket from the default account for a maximum of 23 DCR that expires after 1 block"
+```
+
+> Manual ticket purchasing (Pool Mining)
+
+Every stake pool provides their own instructions which are correct for usage of that specific pool so this information will not be duplicated here.
+
+> Automatic ticket purchasing (Solo Mining)
+
+<i class="fa fa-exclamation-triangle"></i> **Automatic ticket purchasing is not recommended because it may incur transaction fees beyond your control!**
+
+Automatic ticket purchasing can be enabled by adding the relevant configuration options to dcrwallet's configuration file.  See [dcrwallet.conf configuration](/advanced/storing-login-details.md#dcrwallet).
+
+```no-highlight
+; Always keep this amount of DCR in the wallet.
+balancetomaintain=10
+; Enable ticket purchasing and voting.
+enablestakemining=1
+; Prompt for a password on startup to ensure the wallet is unlocked immediately.
+promptpass=1
+; Maximum amount to spend on a ticket.
+ticketmaxprice=10
+```
+
+> Post ticket purchase information
+
+* The ticket price is not spent, although it is removed from your balance as it is not spendable. It is just a deposit. You will get it back when your ticket votes, expires, or is revoked due to not voting.
+* 20 tickets are accepted into the voting pool each block. Tickets that are waiting stay in the mempool. Tickets are moved from the mempool to the voting pool in order of txfee.
+* Tickets take 256 blocks (about a day) to mature. During this time the stake price you paid will not be visible in your total balance.
+* You can keep track of your tickets' status by periodically running:
+```no-highlight
+dcrctl --wallet getstakeinfo
+```
+
+---
+
+## ** <i class="fa fa-code-fork"></i> Considerations and Future Improvements **
+
+This is in no way a definitive guide. There are user defined ticketfee and txfee variables which will help entice proof-of-work (PoW) miners to include your ticket in the ticket pool in front of lower fee purchases. Ticket purchasing has become increasingly competitive since this documentation was started.  A new ticket purchasing tool called [<i class="fa fa-github"></i> dcrticketbuyer](https://github.com/cjepson/dcrticketbuyer) is being developed to help alleviate some of the complexity of buying tickets.
+
+---
+
+## ** <i class="fa fa-book"></i> See also **
+
+[Proof-of-stake Commands](/advanced/program-options.md#pos-commands)
+
+[Proof-of-stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
+
+[Proof-of-stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
+
+[Proof-of-stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
+
+[Proof-of-stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
+
+[Proof-of-stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)
+
+[Wiki - Solo Stake Mining](https://wiki.decred.org/Solo_Stake_Mining)

--- a/docs/mining/proof-of-work.md
+++ b/docs/mining/proof-of-work.md
@@ -1,0 +1,80 @@
+# ** Proof-of-work (PoW) Mining**
+
+---
+
+## ** Solo Mining or Pool Mining **
+
+> <i class="fa fa-male"></i> Solo Mining
+
+<i class="fa fa-exclamation-triangle"></i> **Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of upto 10000Gh/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
+
+> <i class="fa fa-users"></i> Pool Mining
+
+When you mine in a pool, your hashrate is combined with all the other pool miners’ hashrates to look for the correct solution for a block. You will receive a reward based on the amount of work your miner performs in the pool.
+Pool mining distributes shares based on blocks found so you can earn a steady amount of Decred rather than the "all or none" of solo mining.
+
+---
+
+## Obtain a Decred address to receive funds to
+
+Follow the [Getting Started](/getting-started/overview.md) guide and create an address so you can withdraw mining rewards to it.
+
+---
+
+## **<i class="fa fa-life-ring"></i> Sign up for a mining pool**
+
+These mining pools are known to support Decred:
+
+* [http://yiimp.ccminer.org](http://yiimp.ccminer.org)
+* [http://coinmine.pl/dcr](http://coinmine.pl/dcr)
+* [https://dcr.maxminers.net](https://dcr.maxminers.net)
+* [https://dcr.suprnova.cc](https://dcr.suprnova.cc)
+* [https://pool.mn/dcr](https://pool.mn/dcr)
+* [https://zpool.ca](https://zpool.ca)
+
+Mining pools all work more or less the same but you may wish to sign up at multiple pools and see which one suits you the best.
+
+---
+
+## ** GPU drivers/software **
+
+GPU drivers usually contain the libraries needed for mining.  If you have difficulties running the software you may wish to re-install and specifically check that the OpenCL (AMD) or CUDA (NVIDIA) libraries are selected.
+
+---
+
+## **<i class="fa fa-download"></i> Select and download mining software **
+
+> Official Decred Mining Software Builds
+
+Official builds of ccminer and cgminer are available on GitHub at the following URL:
+
+[https://github.com/decred/decred-release/releases/tag/v0.1.0_miners](https://github.com/decred/decred-release/releases/tag/v0.1.0_miners)
+
+Those with an **AMD** graphics card should download **cgminer** for their operating system.
+
+Those with an **NVIDIA** graphics card should download **ccminer** for their operating system.
+
+> Unofficial Miners
+
+Those with an **AMD** graphics card running Windows may want to download [sgminer](https://github.com/tpruvot/sgminer/releases).
+
+---
+
+## **Running the software**
+
+* Decompress and install the software to a place of your choosing.
+* Open a command prompt to that path.
+* Follow your mining pools instructions for setup.
+* Run the miner.  Here are some examples:
+
+ccminer + coinmine:
+
+```no-highlight
+ccminer -a decred -o stratum+tcp://dcr.coinmine.pl:2222 -u username.workerid -p pass --show-diff -q
+```
+
+sgminer + yiimp:
+
+```no-highlight
+./sgminer -I 31 -k decred -u DsThisIsJustAnExampleAddr -p x -o stratum+tcp://yiimp.ccminer.org:4252 --gpu-powertune 20
+```

--- a/docs/mining/proof-of-work.md
+++ b/docs/mining/proof-of-work.md
@@ -6,7 +6,7 @@
 
 > <i class="fa fa-male"></i> Solo Mining
 
-<i class="fa fa-exclamation-triangle"></i> **Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of upto 10000Gh/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
+<i class="fa fa-exclamation-triangle"></i> **Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of up to 10,000Gh/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
 
 > <i class="fa fa-users"></i> Pool Mining
 
@@ -48,11 +48,11 @@ GPU drivers usually contain the libraries needed for mining.  If you have diffic
 
 Official builds of ccminer and cgminer are available on GitHub at the following URL:
 
-[https://github.com/decred/decred-release/releases/tag/v0.1.0_miners](https://github.com/decred/decred-release/releases/tag/v0.1.0_miners)
+[<i class="fa fa-download"></i> https://github.com/decred/decred-release/releases/tag/v0.1.0_miners](https://github.com/decred/decred-release/releases/tag/v0.1.0_miners)
 
-Those with an **AMD** graphics card should download **cgminer** for their operating system.
+Those with an **AMD** graphics card should download **[<i class="fa fa-github"></i> cgminer](https://github.com/decred/cgminer)** for their operating system.
 
-Those with an **NVIDIA** graphics card should download **ccminer** for their operating system.
+Those with an **NVIDIA** graphics card should download **[<i class="fa fa-github"></i> ccminer](https://github.com/decred/ccminer)** for their operating system.
 
 > Unofficial Miners
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,18 +27,8 @@ pages:
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
 - Mining:
   - 'Overview': 'mining/overview.md'
-  - Proof-of-work:
-    - Pool Mining:
-      - cgminer:
-        - 'Windows': 'mining/proof-of-work/pool-mining/cgminer/windows.md'
-        - 'Linux': 'mining/proof-of-work/pool-mining/cgminer/linux.md'
-    - Solo Mining:
-      - cgminer:
-        - 'Windows': 'mining/proof-of-work/solo-mining/cgminer/windows.md'
-        - 'Linux': 'mining/proof-of-work/solo-mining/cgminer/linux.md'
-  - Proof-of-stake:
-    - 'Pool Mining': 'mining/proof-of-stake/pool-mining.md'
-    - 'Solo Mining': 'mining/proof-of-stake/solo-mining.md'
+  - 'Proof-of-work (PoS)': 'mining/proof-of-stake.md'
+  - 'Proof-of-work (PoW)': 'mining/proof-of-work.md'
 - FAQ:
   - 'Overview': 'faq/overview.md'
   - 'General': 'faq/general.md'


### PR DESCRIPTION
I re-wrote both sections to fit into a single page.  I cut out tons of repetitive information that is mostly addressed elsewhere and targeted the content more towards a regular user doing the most common thing.

PoS - Tried to reflect the reality of things as they are today (ticket buying is a fee market now, auto buying isn't recommended and will be replaced soon, and stake pools will launch soon)

PoW - Having a ton of duplicated pages for every mining software/OS didn't make sense to me.  Solo mining is pretty much dead now so I focused on pool mining.

I unlinked the original content but left it intact in to make it easier to review and so we can crib content from those pages more easily in case we want to restore some of it.

Also needs a thorough proof-reading since I've re-written both a couple times and am going a bit cross eyed.