### PR TITLE
Add Installation guide, edit existing documentation

### DIFF
--- a/docs/getting-started/install-guide.md
+++ b/docs/getting-started/install-guide.md
@@ -1,0 +1,126 @@
+# Installation Guide
+
+This guide was last updated for v0.7.0.
+
+---
+
+There are four methods for downloading and installing the Decred software. One is via dcrinstall (cross-platform), one is via the Windows Installer (Windows only of course, and the only way to get Paymetheus as of v0.7.0), another is via the precompiled binary releases (cross-platform), and the other is building the software yourself. The first three methods will be covered here and the fourth may be added at a later date.
+
+## dcrinstall
+
+`dcrinstall` is an automatic installer and upgrader for the Decred software. The newest release can be found here: [https://github.com/decred/decred-release/releases](https://github.com/decred/decred-release/releases). Binaries are provided for Windows, OSX/macOS, Linux, OpenBSD, and FreeBSD. Executing installer will install `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer`. Instructions are provided for Mac, Linux, and Windows below (assumed proficiency for *BSD users).
+
+> OSX/macOS:
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `dcrinstall-darwin-386-v0.7.0` file. <br />
+    For 64-bit computers, download the `dcrinstall-darwin-amd64-v0.7.0` file.
+
+2. Make dcrinstall-darwin-xxxx-vx.x.x an executable within your terminal:
+
+    Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
+    
+    `cd ~/Downloads/` <br />
+    `chmod u+x dcrinstall-darwin-amd64-v0.7.0` <br />
+    `./dcrinstall-darwin-amd64-v0.7.0`
+    
+3. The binaries for `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer` can then be found in the `~/decred/` directory.
+
+> Linux:
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `dcrinstall-linux-386-v0.7.0` file. <br />
+    For 64-bit computers, download the `dcrinstall-linux-amd64-v0.7.0` file. <br />
+    For 32-bit ARM computers, download the `dcrinstall-linux-arm-v0.7.0` file. <br />
+    For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v0.7.0` file.
+
+2. Make dcrinstall-darwin-xxxx-vx.x.x an executable within your terminal:
+
+    Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
+    
+    `cd ~/Downloads/` <br />
+    `chmod u+x dcrinstall-darwin-amd64-v0.7.0` <br />
+    `./dcrinstall-darwin-amd64-v0.7.0` 
+    
+3. The binaries for `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer` can then be found in the `~/decred/` directory.
+
+> Windows:
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `dcrinstall-windows-386-v0.7.0.exe` file. <br /> 
+    For 64-bit computers, download the `dcrinstall-windows-amd64-v0.7.0.exe` file. <br />
+
+2.  Run the dcrinstall executable file.
+
+    You can either double click it or run it from the Command Prompt. 
+    
+3. The binaries for `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer` can then be found in the `%HOMEPATH%\decred\` directory (usually %HOMEPATH% is `C:\Users\username`).
+
+## Binary Releases
+
+The newest Binary Releases can be found here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). With the exception of the `.msi` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be unzip and go, instructions are provided for Mac, Linux, and Windows below (assumed proficiency for *BSD users).
+
+> OSX/macOS
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `decred-darwin-386-v0.7.0.tar.gz` file. <br />
+    For 64-bit computers, download the `decred-darwin-amd64-v0.7.0.tar.gz` file.
+
+2. Navigate to download location and open the .tar file:
+
+    Finder: simply double click on the .tar file. <br />
+    Terminal: use the `tar -xvf filename` command. 
+    
+    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvf decred-darwin-amd64-v0.7.0.tar` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+
+
+> Linux
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `decred-linux-386-v0.7.0.tar.gz` file. <br />
+    For 64-bit computers, download the `decred-darwin-amd64-v0.7.0.tar.gz` file. <br />
+    For 32-bit ARM computers, download the `decred-linux-arm-v0.7.0.tar.gz` file. <br />
+    For 64-bit ARM computers, download the `decred-linux-arm64-v0.7.0.tar.gz` file.
+
+2. Navigate to download location and open the .tar file:
+
+    Finder: simply double click on the .tar file. <br />
+    Terminal: use the `tar -xvf filename` command. 
+    
+    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvf decred-darwin-amd64-v0.7.0.tar` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+
+> Windows
+
+Note: Windows 7/8/10 natively provides support for `.zip` files, therefore it is preferable to use the `.zip` file so that third-party applications aren't required for the `.tar.gz` file. Instructions are provided for the `.zip` file.
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `decred-windows-386-v0.7.0.zip` file. <br />
+    For 64-bit computers, download the `decred-windows-amd64-v0.7.0.zip` file.
+
+2. Navigate to download location and unzip the `.zip` file:
+
+    File Explorer: Right click on the .zip file, select "Extract All.." and a prompt should open asking for the directory to use. The default will extract the `.zip` to a folder with the same name. It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+
+If you decide to download the `.tar.gz` file, it will require two separate extractions in some third-party application (7-zip, winRAR, etc..) to get to the actual binaries.
+
+## Windows Installer
+
+The Windows Installer (`.msi` file) located here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases) will install Paymetheus and Dcrticketbuyer to your computer's Program Files. As of the v0.7.0 release, this is the only way to get Paymetheus (the Windows GUI Decred wallet/node). Installation is pretty straightforward, but instructions are provided below:
+
+1. Download the correct file:
+
+    For 32-bit computers, download the `decred_0.7.0-beta_x86.msi` file. <br />
+    For 64-bit computers, download the `decred_0.7.0-beta_x64.msi` file.
+
+2. Navigate to download location and open the `.msi` file.
+
+3. Follow the installation steps. Within this process you'll be prompted to accept an End-User License Agreement, and be able to select which of the features you wish to install (Paymetheus and/or Dcrticketbuyer).
+
+4. After setup, the features should be installed to your `..\Program Files\Decred\` folder and accessible through the Start Menu (look for `Decred` in the Program list).
+

--- a/docs/getting-started/install-guide.md
+++ b/docs/getting-started/install-guide.md
@@ -4,7 +4,7 @@ This guide was last updated for v0.7.0.
 
 ---
 
-There are four methods for downloading and installing the Decred software. One is via dcrinstall (cross-platform), one is via the Windows Installer (Windows only of course, and the only way to get Paymetheus as of v0.7.0), another is via the precompiled binary releases (cross-platform), and the other is building the software yourself. The first three methods will be covered here and the fourth may be added at a later date.
+There are four methods for downloading and installing the Decred software. One is via dcrinstall (cross-platform), one is via the Windows Installer (Windows only of course, and the only way to get Paymetheus as of v0.7.0), another is via the precompiled binary releases (cross-platform), and the other is building the software yourself (cross-platform). The first three methods will be covered here and the fourth may be added at a later date.
 
 ## dcrinstall
 
@@ -70,12 +70,14 @@ The newest Binary Releases can be found here: [https://github.com/decred/decred-
     For 32-bit computers, download the `decred-darwin-386-v0.7.0.tar.gz` file. <br />
     For 64-bit computers, download the `decred-darwin-amd64-v0.7.0.tar.gz` file.
 
-2. Navigate to download location and open the .tar file:
+2. Navigate to download location and extract the .tar.gz file:
 
-    Finder: simply double click on the .tar file. <br />
-    Terminal: use the `tar -xvf filename` command. 
+    Finder: simply double click on the .tar.gz file. <br />
+    Terminal: use the `tar -xvzf filename.tar.gz` command. 
+
+    **NOTE**: If you are using Safari on macOS Sierra and have the 'Open "safe" files after downloading' preference enabled, .gz and .zip files are automatically uncompressed after download. The `tar -xvzf filename.tar.gz` command results in this error: `tar: Error opening archive: Failed to open 'filename.tar.gz'`. Use `tar -xvzf filename.tar` instead (remove the .gz from the previous command).
     
-    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvf decred-darwin-amd64-v0.7.0.tar` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.7.0.tar.gz` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
 
 
 > Linux
@@ -87,12 +89,12 @@ The newest Binary Releases can be found here: [https://github.com/decred/decred-
     For 32-bit ARM computers, download the `decred-linux-arm-v0.7.0.tar.gz` file. <br />
     For 64-bit ARM computers, download the `decred-linux-arm64-v0.7.0.tar.gz` file.
 
-2. Navigate to download location and open the .tar file:
+2. Navigate to download location and extract the .tar.gz file:
 
-    Finder: simply double click on the .tar file. <br />
-    Terminal: use the `tar -xvf filename` command. 
+    Finder: simply double click on the .tar.gz file. <br />
+    Terminal: use the `tar -xvzf filename.tar.gz` command. 
     
-    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvf decred-darwin-amd64-v0.7.0.tar` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+    Both of these should extract the tar.gz into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.7.0.tar.gz` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
 
 > Windows
 
@@ -111,7 +113,7 @@ If you decide to download the `.tar.gz` file, it will require two separate extra
 
 ## Windows Installer
 
-The Windows Installer (`.msi` file) located here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases) will install Paymetheus and Dcrticketbuyer to your computer's Program Files. As of the v0.7.0 release, this is the only way to get Paymetheus (the Windows GUI Decred wallet/node). Installation is pretty straightforward, but instructions are provided below:
+The Windows Installer (`.msi` file) is located here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). It will install Paymetheus and Dcrticketbuyer to your computer's Program Files. As of the v0.7.0 release, this is the only way to get Paymetheus (the Windows GUI Decred wallet/node). Installation is pretty straightforward, but instructions are provided below:
 
 1. Download the correct file:
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -25,6 +25,15 @@ your wallet.
 * Proof-of-Stake mining (assuming you already have some DCR)
 * Have someone send you some DCR
 
+
+Note: You might soon notice one of the many differences between Decred and other 
+popular cryptocurrencies: the wallet daemon and node daemon are separate.
+A lot of other coins run these functions together in a single daemon.
+For those who choose to use the command line interfaces, this means you must
+run `dcrd` for full node functionality, and `dcrwallet` to store your DCR,
+create transactions and participate in Proof-of-Stake mining/voting.
+
+
 ---
 
 ## **1. <i class="fa fa-user"></i> User Guides**

--- a/docs/getting-started/user-guides/linux.md
+++ b/docs/getting-started/user-guides/linux.md
@@ -6,15 +6,13 @@
 
 > Step One
 
-Download the latest Decred software from the
-[Decred releases page](https://github.com/decred/decred-release/releases). Extract
-it to a directory (e.g., `~/Decred`). Open three command terminals. If
-you are running in headless mode via SSH, you will need to use a
-terminal multiplexer such as `screen`
-([How do I use `screen`?](http://www.howtogeek.com/howto/ubuntu/keep-your-ssh-session-running-when-you-disconnect/))
-or [`tmux`](https://tmux.github.io/). Where you see the instruction to
-move to another terminal, you'll need to start a new window in screen
-or tmux..
+Follow the steps in the following link to [Download and Install Decred](/getting-started/install-guide.md).
+
+*If you are running in headless mode via SSH,* you
+will need to use a terminal multiplexer such as [**screen**](http://www.howtogeek.com/howto/ubuntu/keep-your-ssh-session-running-when-you-disconnect/)
+or [**tmux**](https://tmux.github.io/). Where you see the instruction to
+move to another terminal, you'll need to start a new window in `screen`
+or `tmux`.
 
 > Step Two
 

--- a/docs/getting-started/user-guides/osx.md
+++ b/docs/getting-started/user-guides/osx.md
@@ -6,16 +6,13 @@
 
 > Step One
 
-Download the latest Decred platform from the
-[Decred releases page](https://github.com/decred/decred-release/releases). Extract
-it to a directory (e.g., `~/Decred`).  OS X is frequently identified as
-`Darwin` so the binaries provided are named decred-darwin.  Open three
-command terminals. If you are running in headless mode via SSH, you
-will need to use a terminal multiplexer such as `screen`
-([How do I use `screen`?](http://www.howtogeek.com/howto/ubuntu/keep-your-ssh-session-running-when-you-disconnect/))
-or [`tmux`](https://tmux.github.io/). Where you see the instruction to
-move to another terminal, you'll need to start a new window in screen
-or tmux..
+Follow the steps in the following link to [Download and Install Decred](/getting-started/install-guide.md).
+
+*If you are running in headless mode via SSH,* you
+will need to use a terminal multiplexer such as [**screen**](http://www.howtogeek.com/howto/ubuntu/keep-your-ssh-session-running-when-you-disconnect/)
+or [**tmux**](https://tmux.github.io/). Where you see the instruction to
+move to another terminal, you'll need to start a new window in `screen`
+or `tmux`.
 
 > Step Two
 

--- a/docs/mining/proof-of-stake.md
+++ b/docs/mining/proof-of-stake.md
@@ -51,7 +51,6 @@ administration labor.
 These stake pools are officially recognized:
 
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakepool.net](https://dcr.stakepool.net)
-* [<i class="fa fa-external-link-square"></i> https://decredstakepool.com](https://decredstakepool.com)
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakeminer.com](https://dcr.stakeminer.com)
 * [<i class="fa fa-external-link-square"></i> http://pool.d3c.red](http://pool.d3c.red)
 * [<i class="fa fa-external-link-square"></i> https://dcrstakes.com](https://dcrstakes.com)

--- a/docs/mining/proof-of-work.md
+++ b/docs/mining/proof-of-work.md
@@ -65,7 +65,7 @@ cgminer is a popular miner for **AMD** GPUs that has a long history of use in ma
 
 ccminer is a popular miner for **NVIDIA** GPUs that has a long history of use in many different cryptocurrencies. It is more difficult to use than the decred gominer.
 
-**Official builds of ccminer and cgminer are available on GitHub from the following link:     
+**Official builds of ccminer and cgminer are available on GitHub from the following link: <br />
 [https://github.com/decred/decred-release/releases/tag/v0.1.0_miners](https://github.com/decred/decred-release/releases/tag/v0.1.0_miners)**
 
 > Unofficial Miners

--- a/docs/mining/proof-of-work/pool-mining/gominer/windows.md
+++ b/docs/mining/proof-of-work/pool-mining/gominer/windows.md
@@ -13,12 +13,12 @@ Last updated for gominer v0.6.0.
 
 Visit [https://github.com/decred/decred-binaries/releases/tag/v0.6.1](https://github.com/decred/decred-binaries/releases/tag/v0.6.1) to download the gominer Windows binaries. Within the "Downloads" section you should see the following files:
 
-- `gominer-windows-amd64-cuda-v0.6.0.zip`,     
-- `gominer-windows-amd64-opencl-v0.6.0.zip`,    
+- `gominer-windows-amd64-cuda-v0.6.0.zip`,
+- `gominer-windows-amd64-opencl-v0.6.0.zip`,
 - `gominer-windows-amd64-opencladl-v0.6.0.zip`.
 
-For NVIDIA graphics cards, download the `*-cuda-*.zip` file.     
-For AMD graphics cards from the Radeon and FirePro lines, download the `*-opencladl-*.zip` file.     
+For NVIDIA graphics cards, download the `*-cuda-*.zip` file. <br />
+For AMD graphics cards from the Radeon and FirePro lines, download the `*-opencladl-*.zip` file. <br />
 For other graphics cards, download `*-opencl-*.zip` file.
 
 Extract or Copy all of the files to a new folder. Either remember the pathname to this folder, or open a new File Explorer window to view the contents of the folder (For the rest of this tutorial, we will use `C:\decred\gominer\` as an example). The contents of this folder should be `blake256.cl`, `gominer.exe`, `LICENSE`, `README.md`, and `sample-gominer.conf`.
@@ -27,21 +27,21 @@ Extract or Copy all of the files to a new folder. Either remember the pathname t
 
 For those who are new, please familiarize yourself with some methods to open a command prompt at a specific directory (folder):
 
-- In File Explorer, navigate to specific folder, type `cmd` into the address bar, and press enter.    
-- In File Explorer, navigate to specific folder, click the "File" dropdown, navigate to the "Open command prompt" option, and select "Open command prompt".      
+- In File Explorer, navigate to specific folder, type `cmd` into the address bar, and press enter.
+- In File Explorer, navigate to specific folder, click the "File" dropdown, navigate to the "Open command prompt" option, and select "Open command prompt".
 - Click the start menu or press the Windows key on your keyboard, type `cmd`, and open the "Command Prompt" Desktop App that should appear in the search results. Change the current directory to a specific folder by using the `cd` command, `e.g. cd C:\decred\gominer\`. The `dir` command by itself can be used to see the contents of the current directory.
 
 ### **Setup *gominer* Configuration File**
 
 > Step 1: Choose Mining Pool
 
-Before we begin this step, it is important that you've already signed up for a mining pool account (if required by your chosen mining pool, you'll have to create a worker at the pool's website). Record your worker's login and password, and the pool's stratum+tcp address:port for later use. 
+Before we begin this step, it is important that you've already signed up for a mining pool account (if required by your chosen mining pool, you'll have to create a worker at the pool's website). Record your worker's login and password, and the pool's stratum+tcp address:port for later use.
 
 If this is new to you, here are a few guides for creating workers on some of the Decred mining pools (WARNING: do not forget your PIN you set during account creation - you will be unable to withdraw any mined DCR without it):
 
-- [https://dcr.maxminers.net/index.php?page=gettingstarted](https://dcr.maxminers.net/index.php?page=gettingstarted)    
-- [https://dcr.suprnova.cc/index.php?page=gettingstarted](https://dcr.suprnova.cc/index.php?page=gettingstarted)    
-- [https://www2.coinmine.pl/dcr/index.php?page=gettingstarted](https://www2.coinmine.pl/dcr/index.php?page=gettingstarted)    
+- [https://dcr.maxminers.net/index.php?page=gettingstarted](https://dcr.maxminers.net/index.php?page=gettingstarted)
+- [https://dcr.suprnova.cc/index.php?page=gettingstarted](https://dcr.suprnova.cc/index.php?page=gettingstarted)
+- [https://www2.coinmine.pl/dcr/index.php?page=gettingstarted](https://www2.coinmine.pl/dcr/index.php?page=gettingstarted)
 - [https://pool.mn/dcr/index.php?page=gettingstarted](https://pool.mn/dcr/index.php?page=gettingstarted)
 
 > Step 2: Verify Device ID#
@@ -56,10 +56,10 @@ Within the "General settings" section:
 
 - set `devices=` to the Device ID#(s) recorded by using the `gominer.exe -l` command in the Step 2. Multiple devices should be separated by comma, e.g. `devices=2,3`.
 
-Within the "Mining settings" section: 
+Within the "Mining settings" section:
 
 - set `pool=` to the stratum+tcp address:port of the mining pool of your choice, e.g. decredpool.org uses `stratum+tcp://stratum.decredpool.org:3333` (WARNING: the http://address:port will not work with gominer - stratum+tcp *must* be used).
-- set `pooluser=` to your worker's login. 
+- set `pooluser=` to your worker's login.
 - set `poolpass=` to your worker's password.
 
 After these changes have been made, Save As or Save + Rename the file as gominer.conf.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ extra_css:
 pages:
 - Home: 'index.md'
 - Getting Started:
+  - 'Download and Install Decred': 'getting-started/install-guide.md'
   - 'Overview': 'getting-started/overview.md'
   - User Guides:
     - 'Windows Command Line': 'getting-started/user-guides/windows.md'


### PR DESCRIPTION
* Remove decredstakepool.com from list of stakepools on PoS page
* Add dcrd, dcrwallet clause about separation of node/wallet software to User Guide Overview page
* Edit step 1 of the OSX and Linux user guides for clarity, link back to installation guide
* Add install-guide.md
* Add install guide to navigation
* Remove extra whitespace from PoW page and gominer Windows Guide, replace with <br />

fixes #55 