### PR TITLE
Update installation guide.

### DIFF
--- a/docs/getting-started/install-guide.md
+++ b/docs/getting-started/install-guide.md
@@ -1,10 +1,10 @@
 # Installation Guide
 
-This guide was last updated for v0.7.0.
+This guide was last updated for v0.8.0.
 
 ---
 
-There are four methods for downloading and installing the Decred software. One is via dcrinstall (cross-platform), one is via the Windows Installer (Windows only of course, and the only way to get Paymetheus as of v0.7.0), another is via the precompiled binary releases (cross-platform), and the other is building the software yourself (cross-platform). The first three methods will be covered here and the fourth may be added at a later date.
+There are four methods for downloading and installing the Decred software. One is via dcrinstall (cross-platform), one is via the Windows Installer (Windows only of course, and the only way to get Paymetheus as of v0.8.0), another is via the precompiled binary releases (cross-platform), and the other is building the software yourself (cross-platform). The first three methods will be covered here and the fourth may be added at a later date.
 
 ## dcrinstall
 
@@ -14,16 +14,16 @@ There are four methods for downloading and installing the Decred software. One i
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `dcrinstall-darwin-386-v0.7.0` file. <br />
-    For 64-bit computers, download the `dcrinstall-darwin-amd64-v0.7.0` file.
+    For 32-bit computers, download the `dcrinstall-darwin-386-v0.8.0` file. <br />
+    For 64-bit computers, download the `dcrinstall-darwin-amd64-v0.8.0` file.
 
 2. Make dcrinstall-darwin-xxxx-vx.x.x an executable within your terminal:
 
     Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
     
     `cd ~/Downloads/` <br />
-    `chmod u+x dcrinstall-darwin-amd64-v0.7.0` <br />
-    `./dcrinstall-darwin-amd64-v0.7.0`
+    `chmod u+x dcrinstall-darwin-amd64-v0.8.0` <br />
+    `./dcrinstall-darwin-amd64-v0.8.0`
     
 3. The binaries for `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer` can then be found in the `~/decred/` directory.
 
@@ -31,18 +31,18 @@ There are four methods for downloading and installing the Decred software. One i
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `dcrinstall-linux-386-v0.7.0` file. <br />
-    For 64-bit computers, download the `dcrinstall-linux-amd64-v0.7.0` file. <br />
-    For 32-bit ARM computers, download the `dcrinstall-linux-arm-v0.7.0` file. <br />
-    For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v0.7.0` file.
+    For 32-bit computers, download the `dcrinstall-linux-386-v0.8.0` file. <br />
+    For 64-bit computers, download the `dcrinstall-linux-amd64-v0.8.0` file. <br />
+    For 32-bit ARM computers, download the `dcrinstall-linux-arm-v0.8.0` file. <br />
+    For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v0.8.0` file.
 
 2. Make dcrinstall-darwin-xxxx-vx.x.x an executable within your terminal:
 
     Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
     
     `cd ~/Downloads/` <br />
-    `chmod u+x dcrinstall-darwin-amd64-v0.7.0` <br />
-    `./dcrinstall-darwin-amd64-v0.7.0` 
+    `chmod u+x dcrinstall-darwin-amd64-v0.8.0` <br />
+    `./dcrinstall-darwin-amd64-v0.8.0` 
     
 3. The binaries for `dcrd`, `dcrwallet`, `dcrctl`, and `dcrticketbuyer` can then be found in the `~/decred/` directory.
 
@@ -50,8 +50,8 @@ There are four methods for downloading and installing the Decred software. One i
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `dcrinstall-windows-386-v0.7.0.exe` file. <br /> 
-    For 64-bit computers, download the `dcrinstall-windows-amd64-v0.7.0.exe` file. <br />
+    For 32-bit computers, download the `dcrinstall-windows-386-v0.8.0.exe` file. <br /> 
+    For 64-bit computers, download the `dcrinstall-windows-amd64-v0.8.0.exe` file. <br />
 
 2.  Run the dcrinstall executable file.
 
@@ -67,8 +67,8 @@ The newest Binary Releases can be found here: [https://github.com/decred/decred-
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `decred-darwin-386-v0.7.0.tar.gz` file. <br />
-    For 64-bit computers, download the `decred-darwin-amd64-v0.7.0.tar.gz` file.
+    For 32-bit computers, download the `decred-darwin-386-v0.8.0.tar.gz` file. <br />
+    For 64-bit computers, download the `decred-darwin-amd64-v0.8.0.tar.gz` file.
 
 2. Navigate to download location and extract the .tar.gz file:
 
@@ -77,24 +77,24 @@ The newest Binary Releases can be found here: [https://github.com/decred/decred-
 
     **NOTE**: If you are using Safari on macOS Sierra and have the 'Open "safe" files after downloading' preference enabled, .gz and .zip files are automatically uncompressed after download. The `tar -xvzf filename.tar.gz` command results in this error: `tar: Error opening archive: Failed to open 'filename.tar.gz'`. Use `tar -xvzf filename.tar` instead (remove the .gz from the previous command).
     
-    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.7.0.tar.gz` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+    Both of these should extract the tar into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.8.0.tar.gz` should extract to `decred-darwin-amd64-v0.8.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
 
 
 > Linux
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `decred-linux-386-v0.7.0.tar.gz` file. <br />
-    For 64-bit computers, download the `decred-darwin-amd64-v0.7.0.tar.gz` file. <br />
-    For 32-bit ARM computers, download the `decred-linux-arm-v0.7.0.tar.gz` file. <br />
-    For 64-bit ARM computers, download the `decred-linux-arm64-v0.7.0.tar.gz` file.
+    For 32-bit computers, download the `decred-linux-386-v0.8.0.tar.gz` file. <br />
+    For 64-bit computers, download the `decred-darwin-amd64-v0.8.0.tar.gz` file. <br />
+    For 32-bit ARM computers, download the `decred-linux-arm-v0.8.0.tar.gz` file. <br />
+    For 64-bit ARM computers, download the `decred-linux-arm64-v0.8.0.tar.gz` file.
 
 2. Navigate to download location and extract the .tar.gz file:
 
     Finder: simply double click on the .tar.gz file. <br />
     Terminal: use the `tar -xvzf filename.tar.gz` command. 
     
-    Both of these should extract the tar.gz into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.7.0.tar.gz` should extract to `decred-darwin-amd64-v0.7.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
+    Both of these should extract the tar.gz into a folder that shares the same name. (`e.g. tar -xvzf decred-darwin-amd64-v0.8.0.tar.gz` should extract to `decred-darwin-amd64-v0.8.0`). It should include `dcrctl`, `dcrd`, `dcrticketbuyer`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, `sample-dcrwallet.conf`, and `ticketbuyer-example.conf`.
 
 > Windows
 
@@ -102,8 +102,8 @@ Note: Windows 7/8/10 natively provides support for `.zip` files, therefore it is
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `decred-windows-386-v0.7.0.zip` file. <br />
-    For 64-bit computers, download the `decred-windows-amd64-v0.7.0.zip` file.
+    For 32-bit computers, download the `decred-windows-386-v0.8.0.zip` file. <br />
+    For 64-bit computers, download the `decred-windows-amd64-v0.8.0.zip` file.
 
 2. Navigate to download location and unzip the `.zip` file:
 
@@ -113,16 +113,15 @@ If you decide to download the `.tar.gz` file, it will require two separate extra
 
 ## Windows Installer
 
-The Windows Installer (`.msi` file) is located here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). It will install Paymetheus and Dcrticketbuyer to your computer's Program Files. As of the v0.7.0 release, this is the only way to get Paymetheus (the Windows GUI Decred wallet/node). Installation is pretty straightforward, but instructions are provided below:
+The Windows Installer (`.msi` file) is located here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). It will install Paymetheus to your computer's Program Files folder. Installation is pretty straightforward, but instructions are provided below:
 
 1. Download the correct file:
 
-    For 32-bit computers, download the `decred_0.7.0-beta_x86.msi` file. <br />
-    For 64-bit computers, download the `decred_0.7.0-beta_x64.msi` file.
+    For 32-bit computers, download the `decred_0.8.0-beta_x86.msi` file. <br />
+    For 64-bit computers, download the `decred_0.8.0-beta_x64.msi` file.
 
 2. Navigate to download location and open the `.msi` file.
 
-3. Follow the installation steps. Within this process you'll be prompted to accept an End-User License Agreement, and be able to select which of the features you wish to install (Paymetheus and/or Dcrticketbuyer).
+3. Follow the installation steps. Within this process you'll be prompted to accept an End-User License Agreement.
 
-4. After setup, the features should be installed to your `..\Program Files\Decred\` folder and accessible through the Start Menu (look for `Decred` in the Program list).
-
+4. After setup, the features should be installed to your `..\Program Files\Decred\` folder and accessible through the Start Menu (look for `Decred` in the Program list)

--- a/docs/getting-started/user-guides/paymetheus.md
+++ b/docs/getting-started/user-guides/paymetheus.md
@@ -7,10 +7,7 @@ About the only thing Paymetheus doesn't do is PoS voting.
 ---
 
 ## **Download and Install** ##
-The first thing you'll need to do is get a copy of Paymetheus. You will find the downloads [here](https://github.com/decred/decred-binaries/releases). 
-Download the file for your operating system and install. Once you're done, run the 'Decred' program.
-You'll notice a program called "Paymetheus Standalone". This is for people who are
-running a seperate 'dcrd' server. You might want to do this for solo [Proof of Stake](/mining/proof-of-stake.md) mining.
+Download and installation instructions are available [here](/getting-started/install-guide.md#windows-installer)
 
 ---
 


### PR DESCRIPTION
Resolves #66 
Update to version 0.8.0. Mostly just a version bump. Can Linux/Mac users confirm their instructions are still valid?