### PR TITLE
Add using-testnet.md

### DIFF
--- a/de_docs/getting-started/using-testnet.md
+++ b/de_docs/getting-started/using-testnet.md
@@ -24,11 +24,24 @@ To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` applicati
 
 ---
 
-<!-- ## Decrediton 
+## Decrediton 
 
 To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
 
-___ -->
+For Linux, 
+
+1. Open your terminal and navigate to the directory with the decrediton executable.
+2. Issue the command `./decrediton --testnet`.
+3. Decrediton will launch and attempt to connect to testnet2.
+
+For macOS/OSX,
+
+1. Open your terminal and issue the following command: `/Applications/decrediton.app/Contents/MacOS/decrediton --testnet`
+2. Decrediton will launch and attempt to connect to testnet2.
+
+Remember, if you want to switch Decrediton back to mainnet, you'll need to issue those commands with the `--mainnet` flag.
+
+---
 
 ## Command-Line Suite
 

--- a/de_docs/getting-started/using-testnet.md
+++ b/de_docs/getting-started/using-testnet.md
@@ -1,0 +1,50 @@
+# Using Testnet Guide
+
+last updated for testnet2
+
+---
+
+## Why Use Testnet?
+
+The testnet is a wonderful place where you can experiment with the Decred applications without worrying that a mistake will cost you real money. It is actually recommended that people use the testnet to learn the basics of the Decred software and any new features.
+
+Decred is currently on its 2nd Testnet, also known as testnet2. Testnets are periodically reset to help keep a manageable blockchain file size. 
+
+---
+
+## How to Run a Testnet Node
+
+Running a testnet2 node is incredibly easy. You application of choice will need to download the testnet2 blockchain, and you will need to create a new wallet file for testnet2 use. Your mainnet blockchain and wallet files will remain untouched. Switching between the two is incredibly easy.
+
+---
+
+## Paymetheus
+
+To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` application instead of the usual `Decred` application. You will then be walked through the wallet creation (the same steps in the [Paymetheus Setup guide](/getting-started/user-guides/paymetheus.md)). After `dcrd` finishes syncing in the background, you'll then be able to fill your `Paymetheus` wallet with testnet DCR and familiarize yourself with the software.
+
+---
+
+<!-- ## Decrediton 
+
+To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
+
+___ -->
+
+## Command-Line Suite
+
+To launch `dcrd` and `dcrwallet` on testnet, simply add the `--testnet` flag to your launch command. Alternatively, you could put `testnet=1` in all of your config files, but it's usually much faster to use the startup flag.
+
+On the first launch of `dcrd --testnet`, `dcrd` will begin downloading the testnet2 blockchain to the `data/testnet2` folder of `dcrd`'s home directory.
+
+Before you're able to launch `dcrwallet` with the `--testnet` flag, you must create a separate testnet wallet using the `dcrwallet --testnet --create` command. The steps are the same as those found in the [dcrwallet Setup Guide](/getting-started/user-guides/dcrwallet-setup.md). 
+
+To issue commands to both `dcrwallet` and `dcrd`, you must also add the `--testnet` flag to any of the `dcrctl` commands that you use. E.g. you would issue the `dcrctl --testnet --wallet getbalance` command to check your testnet balance. 
+
+---
+
+## Acquiring Testnet Coins
+
+You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with the testnet.
+
+---
+

--- a/de_mkdocs.yml
+++ b/de_mkdocs.yml
@@ -35,6 +35,7 @@ pages:
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
   - 'Mainnet Voting Guide': 'getting-started/user-guides/agenda-voting.md'
+  - 'Using Testnet': 'getting-started/using-testnet.md'
   - 'Decred Constitution': 'getting-started/constitution.md'
 - Mining:
   - 'Proof-of-Stake (PoS)': 'mining/proof-of-stake.md'

--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -12,6 +12,8 @@ This beginner's guide is a path to getting the Decred software up and running. Y
 
 You'll need to follow an [Installation Guide](#installation-guides), and then follow the path for the application of your choice below. After your application is set-up, go through the [General Guides](#general-guides) at the bottom of this page. If you have any questions along the way, join us in our [Slack](/support-directory.md#join-us-on-slack).
 
+**NOTE: Using Testnet is highly recommended for learning how to use the Decred software without the fear of making a mistake and losing real money. After following the guides to setup your choice of software, please visit the [Using Testnet guide](/getting-started/using-testnet.md) to learn how to launch your application onto Decred's testnet.**
+
 ---
 
 ## **Applications**
@@ -81,6 +83,7 @@ The following guides, in order, will get you started with the Command-Line Appli
 
 The following guides are independent of the different applications:
 
+* [Using Testnet](/getting-started/using-testnet.md)
 * [Obtaining DCR](/getting-started/obtaining-dcr.md)
 * [Using the Block Explorer](/getting-started/using-the-block-explorer.md)
 * [Proof-of-Stake Guide](/mining/proof-of-stake.md)

--- a/docs/getting-started/using-testnet.md
+++ b/docs/getting-started/using-testnet.md
@@ -1,12 +1,12 @@
 # Using Testnet Guide
 
-last updated for v1.0.0/testnet2
+last updated for testnet2
 
 ---
 
 ## Why Use Testnet?
 
-Testnet2 is a wonderful place where you can experiment with the Decred applications without worrying that a mistake will cost you real money. It is actually recommended that people use the Testnet2 to learn the basics of the Decred software or any new features.
+The testnet is a wonderful place where you can experiment with the Decred applications without worrying that a mistake will cost you real money. It is actually recommended that people use the testnet to learn the basics of the Decred software and any new features.
 
 Decred is currently on its 2nd Testnet, also known as testnet2. Testnets are periodically reset to help keep a manageable blockchain file size. 
 
@@ -20,27 +20,31 @@ Running a testnet2 node is incredibly easy. You application of choice will need 
 
 ## Paymetheus
 
-To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` application instead of the usual `Decred` application. You will then be walked through the wallet creation (the same steps in the [Paymetheus Setup guide](/getting-started/user-guides/paymetheus.md)). After `dcrd` finishes syncing in the background, you'll then be able to fill your `Paymetheus` wallet with tDCR and familiarize yourself with the software.
+To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` application instead of the usual `Decred` application. You will then be walked through the wallet creation (the same steps in the [Paymetheus Setup guide](/getting-started/user-guides/paymetheus.md)). After `dcrd` finishes syncing in the background, you'll then be able to fill your `Paymetheus` wallet with testnet DCR and familiarize yourself with the software.
 
 ---
 
+<!-- ## Decrediton 
+
+To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
+
+___ -->
+
 ## Command-Line Suite
 
-To launch `dcrd` and `dcrwallet` on testnet2, simply add the `--testnet` flag to your launch command. Alternatively, you could put `testnet=true` in all of your config files, but it's usually much faster to use the startup flag.
+To launch `dcrd` and `dcrwallet` on testnet, simply add the `--testnet` flag to your launch command. Alternatively, you could put `testnet=1` in all of your config files, but it's usually much faster to use the startup flag.
 
 On the first launch of `dcrd --testnet`, `dcrd` will begin downloading the testnet2 blockchain to the `data/testnet2` folder of `dcrd`'s home directory.
 
-Before you're able to launch `dcrwallet` with the `--testnet` flag, you must create a separate Testnet wallet using the `dcrwallet --testnet --create` command. The steps are the same as those found in the [dcrwallet Setup Guide](/getting-started/user-guides/dcrwallet-setup.md). 
+Before you're able to launch `dcrwallet` with the `--testnet` flag, you must create a separate testnet wallet using the `dcrwallet --testnet --create` command. The steps are the same as those found in the [dcrwallet Setup Guide](/getting-started/user-guides/dcrwallet-setup.md). 
 
 To issue commands to both `dcrwallet` and `dcrd`, you must also add the `--testnet` flag to any of the `dcrctl` commands that you use. E.g. you would issue the `dcrctl --testnet --wallet getbalance` command to check your testnet balance. 
 
 ---
 
-## Acquiring Testnet2 Coins
+## Acquiring Testnet Coins
 
-You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with testnet2.
+You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with the testnet.
 
 ---
-
-<!-- TODO: ADD DECREDITON SECTION -->
 

--- a/docs/getting-started/using-testnet.md
+++ b/docs/getting-started/using-testnet.md
@@ -1,0 +1,46 @@
+# Using Testnet Guide
+
+last updated for v1.0.0/testnet2
+
+---
+
+## Why Use Testnet?
+
+Testnet2 is a wonderful place where you can experiment with the Decred applications without worrying that a mistake will cost you real money. It is actually recommended that people use the Testnet2 to learn the basics of the Decred software or any new features.
+
+Decred is currently on its 2nd Testnet, also known as testnet2. Testnets are periodically reset to help keep a manageable blockchain file size. 
+
+---
+
+## How to Run a Testnet Node
+
+Running a testnet2 node is incredibly easy. You application of choice will need to download the testnet2 blockchain, and you will need to create a new wallet file for testnet2 use. Your mainnet blockchain and wallet files will remain untouched. Switching between the two is incredibly easy.
+
+---
+
+## Paymetheus
+
+To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` application instead of the usual `Decred` application. You will then be walked through the wallet creation (the same steps in the [Paymetheus Setup guide](/getting-started/user-guides/paymetheus.md)). After `dcrd` finishes syncing in the background, you'll then be able to fill your `Paymetheus` wallet with tDCR and familiarize yourself with the software.
+
+---
+
+## Command-Line Suite
+
+To launch `dcrd` and `dcrwallet` on testnet2, simply add the `--testnet` flag to your launch command. Alternatively, you could put `testnet=true` in all of your config files, but it's usually much faster to use the startup flag.
+
+On the first launch of `dcrd --testnet`, `dcrd` will begin downloading the testnet2 blockchain to the `data/testnet2` folder of `dcrd`'s home directory.
+
+Before you're able to launch `dcrwallet` with the `--testnet` flag, you must create a separate Testnet wallet using the `dcrwallet --testnet --create` command. The steps are the same as those found in the [dcrwallet Setup Guide](/getting-started/user-guides/dcrwallet-setup.md). 
+
+To issue commands to both `dcrwallet` and `dcrd`, you must also add the `--testnet` flag to any of the `dcrctl` commands that you use. E.g. you would issue the `dcrctl --testnet --wallet getbalance` command to check your testnet balance. 
+
+---
+
+## Acquiring Testnet2 Coins
+
+You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with testnet2.
+
+---
+
+<!-- TODO: ADD DECREDITON SECTION -->
+

--- a/docs/getting-started/using-testnet.md
+++ b/docs/getting-started/using-testnet.md
@@ -24,11 +24,24 @@ To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` applicati
 
 ---
 
-<!-- ## Decrediton 
+## Decrediton 
 
 To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
 
-___ -->
+For Linux, 
+
+1. Open your terminal and navigate to the directory with the decrediton executable.
+2. Issue the command `./decrediton --testnet`.
+3. Decrediton will launch and attempt to connect to testnet2.
+
+For macOS/OSX,
+
+1. Open your terminal and issue the following command: `/Applications/decrediton.app/Contents/MacOS/decrediton --testnet`
+2. Decrediton will launch and attempt to connect to testnet2.
+
+Remember, if you want to switch Decrediton back to mainnet, you'll need to issue those commands with the `--mainnet` flag.
+
+___ 
 
 ## Command-Line Suite
 

--- a/es_docs/getting-started/using-testnet.md
+++ b/es_docs/getting-started/using-testnet.md
@@ -1,0 +1,50 @@
+# Using Testnet Guide
+
+last updated for testnet2
+
+---
+
+## Why Use Testnet?
+
+The testnet is a wonderful place where you can experiment with the Decred applications without worrying that a mistake will cost you real money. It is actually recommended that people use the testnet to learn the basics of the Decred software and any new features.
+
+Decred is currently on its 2nd Testnet, also known as testnet2. Testnets are periodically reset to help keep a manageable blockchain file size. 
+
+---
+
+## How to Run a Testnet Node
+
+Running a testnet2 node is incredibly easy. You application of choice will need to download the testnet2 blockchain, and you will need to create a new wallet file for testnet2 use. Your mainnet blockchain and wallet files will remain untouched. Switching between the two is incredibly easy.
+
+---
+
+## Paymetheus
+
+To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` application instead of the usual `Decred` application. You will then be walked through the wallet creation (the same steps in the [Paymetheus Setup guide](/getting-started/user-guides/paymetheus.md)). After `dcrd` finishes syncing in the background, you'll then be able to fill your `Paymetheus` wallet with testnet DCR and familiarize yourself with the software.
+
+---
+
+<!-- ## Decrediton 
+
+To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
+
+___ -->
+
+## Command-Line Suite
+
+To launch `dcrd` and `dcrwallet` on testnet, simply add the `--testnet` flag to your launch command. Alternatively, you could put `testnet=1` in all of your config files, but it's usually much faster to use the startup flag.
+
+On the first launch of `dcrd --testnet`, `dcrd` will begin downloading the testnet2 blockchain to the `data/testnet2` folder of `dcrd`'s home directory.
+
+Before you're able to launch `dcrwallet` with the `--testnet` flag, you must create a separate testnet wallet using the `dcrwallet --testnet --create` command. The steps are the same as those found in the [dcrwallet Setup Guide](/getting-started/user-guides/dcrwallet-setup.md). 
+
+To issue commands to both `dcrwallet` and `dcrd`, you must also add the `--testnet` flag to any of the `dcrctl` commands that you use. E.g. you would issue the `dcrctl --testnet --wallet getbalance` command to check your testnet balance. 
+
+---
+
+## Acquiring Testnet Coins
+
+You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with the testnet.
+
+---
+

--- a/es_docs/getting-started/using-testnet.md
+++ b/es_docs/getting-started/using-testnet.md
@@ -24,11 +24,24 @@ To launch `Paymetheus` on testnet2, simply launch the `Decred Testnet` applicati
 
 ---
 
-<!-- ## Decrediton 
+## Decrediton 
 
 To launch `Decrediton` on testnet2, you have to launch `Decrediton` from the command line with the `--testnet` flag. Keep in mind that using the flag once will make it always start in that mode until you use the `--mainnet` flag to switch back to the mainnet blockchain.
 
-___ -->
+For Linux, 
+
+1. Open your terminal and navigate to the directory with the decrediton executable.
+2. Issue the command `./decrediton --testnet`.
+3. Decrediton will launch and attempt to connect to testnet2.
+
+For macOS/OSX,
+
+1. Open your terminal and issue the following command: `/Applications/decrediton.app/Contents/MacOS/decrediton --testnet`
+2. Decrediton will launch and attempt to connect to testnet2.
+
+Remember, if you want to switch Decrediton back to mainnet, you'll need to issue those commands with the `--mainnet` flag.
+
+___
 
 ## Command-Line Suite
 

--- a/es_mkdocs.yml
+++ b/es_mkdocs.yml
@@ -35,6 +35,7 @@ pages:
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
   - 'Mainnet Voting Guide': 'getting-started/user-guides/agenda-voting.md'
+  - 'Using Testnet': 'getting-started/using-testnet.md'
   - 'Constitución de Decred': 'getting-started/constitution.md'
 - Mining:
   - 'Proof-of-Stake (PoS)': 'mining/proof-of-stake.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ pages:
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
   - 'Mainnet Voting Guide': 'getting-started/user-guides/agenda-voting.md'
+  - 'Using Testnet': 'getting-started/using-testnet.md'
   - 'Decred Constitution': 'getting-started/constitution.md'
 - Mining:
   - 'Proof-of-Stake (PoS)': 'mining/proof-of-stake.md'


### PR DESCRIPTION
This PR adds the Using Testnet Guide (/getting-started/using-testnet.md), and recommends using the testnet to beginners on the beginner-guide.md page.

Because testnet2 currently requires compiling from source, I think this PR should be held until new binaries are released, but comments, criticisms, etc,.. much appreciated.  

Closes #78 