### PR TITLE
Add dcrwallet ticket purchase guide

### DIFF
--- a/de_docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/de_docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,0 +1,208 @@
+# **Buying Tickets With dcrwallet**
+
+Last updated for v0.8.2 on 4/18/2017
+
+This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
+
+**Prerequisites:**
+
+- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
+- [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
+- Familiarize yourself with the [basics of using dcrctl](/getting-started/user-guides/dcrctl-basics.md).
+- Familiarize yourself with the [staking process](/mining/proof-of-stake.md#staking-101) and the [ticket lifecycle](/mining/proof-of-stake.md#ticket-lifecycle)
+
+This guide assumes you have set up `dcrd` and `dcrwallet` using configuration files. If you used `dcrinstall`, you have configuration files already. Using configuration files is highly recommended - it makes for an easier time issuing commands to `dcrwallet` and `dcrd` through `dcrctl`. A guide for minimum configuration (saving your RPC username and RPC password) can be found [here](/getting-started/startup-basics.md#minimum-configuration). 
+
+NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]` and `[Ticket Buyer Options]`. Any setting prefixed by 'tickeybuyer.' must be placed within the lower `[Ticket Buyer Options]` section. All other settings go within `[Application Options]`. 
+
+---
+
+## **Decisions**
+
+There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
+
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+
+Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+
+Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
+
+---
+
+## **Solo-voting**
+
+REMINDER: Solo-voting with a voting wallet that doesn't stay online 24/7 may result in missed votes and forfeited stake rewards.
+
+To solo-vote, you simply set the enablevoting option when starting `dcrwallet`, unlock the wallet with your private passphrase, and buy tickets. With enablevoting enabled and `dcrwallet` unlocked, your wallet will automatically handle voting.
+
+To set up your `dcrwallet` for solo-staking, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enablevoting=1
+
+Once restarted with that line in `dcrwallet.conf` your wallet will be configured for solo-voting and you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Stakepool-voting**
+
+To allow a stakepool to vote for you, you first have to sign up for a stakepool. A list of them can be found [here](/mining/proof-of-stake.md#list-of-stakepools). After signing up, there should be directions for creating a new P2SH address and importing your multi-sig voting script. A brief overview is provided here:
+
+1. With your wallet open, issue the `dcrctl --wallet getnewaddress` command to retrieve an address.
+2. Using that address, issue the `dcrctl --wallet validateaddress <address from step 1>` command. This should return a JSON object that will be displayed like so:
+```
+{
+  "isvalid": true,
+  "address": "DsExampleAddr1For2Demo3PurposesOnly",
+  "ismine": true,
+  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
+  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
+  "iscompressed": true,
+  "account": "voting"
+}
+```
+3. Copy the `pubkeyaddr` into the stakepool's "Submit Address" form and hit the submit button. The page should redirect you to the tickets page, which will display more instructions.
+4. At the top of the tickets page, you should see a "Ticket Information" section. Copy your "Redeem Script" and use it to issue the `dcrctl --wallet importscript <Insert Redeem Script Here>` command.
+
+With the stakepool configured and your multi-sig script imported to your wallet, you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Ticket Purchasing**
+
+Both manual and automatic ticket purchasing require your wallet to be unlocked via the `dcrcrl --wallet walletpassphrase <private passphrase> <time limit>` command.
+
+There are three things you might want to understand before purchasing tickets: the `purchaseticket` command, when/why a `ticketfee` is important, and the significance of `ticket price`.
+
+> purchaseticket Command
+
+The `purchaseticket` command will be used to purchase tickets whether manual or automatic. Let's take a closer look at the command and its arguments:
+
+```
+purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
+```
+
+1. `fromaccount`    =  Required String: The account from which to purchase tickets (e.g. "default").
+2. `spendlimit`     =  Required Number: Limit on the amount to spend on ticket (e.g. 50).
+3. `minconf`        =  Optional Number: Minimum number of block confirmations required (e.g. 1).
+4. `ticketaddress`  =  Optional String: The ticket address to which voting rights are given
+5. `numtickets`     =  Optional Number: The number of tickets to purchase at once (e.g. 1)
+6. `pooladdress`    =  Optional String: The address to pay stake pool fees to
+7. `poolfees`       =  Optional Number: The percentage of fees to pay to the stake pool (e.g. 5)
+8. `expiry`         =  Optional Number: The block height where unmined tickets will expire from the mempool, returning the original DCR to your "fromaccount". If left blank, tickets will only expire in the mempool when the ticket price changes.
+9. `comment`        =  Optional String: This argument is unused and has no significance. 
+
+> Ticket Fees
+
+Your `ticketfee` is the DCR/kB rate you'll pay to have your ticket purchase be included in a block by a miner. You'll notice that the above ticketpurchase command doesn't include any `ticketfee` arguments. The `ticketfee` argument can be set two ways.
+
+1. During startup by adding `ticketfee=<fee rate>` to the `[Application Options]` of your `dcrwallet.conf`.
+2. While your wallet is running, using the `dcrctl --wallet setticketfee <fee rate>` command. This is not a permanent setting and will default to 0.01 every time your wallet is restarted unless a ticketfee is specified in `dcrwallet.conf`.
+
+Why are ticketfees important? Usually the default fee of 0.01 is enough to get your tickets mined. The exception is during a fee war event. When the ticket price falls very low, demand outpaces supply (there are only a maximum of 2880 tickets available at each price interval). This creates a fee war, with stakeholders competing to get their tickets mined before the price changes.
+
+With these two things in mind, let's continue to the two methods for purchasing tickets.
+
+> Ticket Price
+
+To get the current ticket price, issue the `dcrctl --wallet getstakeinfo` command and look for the `difficulty` value. This is the price of each ticket in the current price window. You'll want to adjust your `spendlimit` argument in the `purchaseticket` command to be greater than this `difficulty` value when purchasing tickets manually.
+
+--- 
+
+#### **Manual Ticket Purchase**
+
+Before manually purchasing tickets, it is recommended to check for a ticketfee war and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command. Third party sites such as https://dcrstats.com and https://posmaster.info can be used to find the average ticketfee in the mempool, although you may oftentimes be able to purchase a ticket with a ticketfee lower than the average.
+
+> Solo Tickets
+
+To purchase tickets used for solo-staking, you only need to specify the `fromaccount` and `spendlimit` arguments while using the `purchaseticket` command. For example: `dcrctl --wallet purchaseticket "default" 50` would use DCR from your `default` account to purchase a ticket if the current ticket price was a max of 50 DCR.
+
+If you wish to specify the `numticket` or `expiry` arguments, you would specify a `minconf` of 1, an empty `ticketaddress` (""), an empty `pooladdress` (""), and an empty `poolfees` (0). Two example follow:
+
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5` would purchase 5 tickets, as the 5th argument (`numtickets`) is set to 5.
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5 "" 0 100000` would purchase 5 tickets that would expire from the mempool if not mined by block 100,000, as the 8th argument (`expiry`) is set to 100000.
+ 
+Be sure to check for a fee war event and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command.
+
+> Pool Tickets
+
+To purchase tickets with their voting rights delegated to a stakepool, we have to use the full `purchaseticket` command.
+
+* Your `ticketaddress` is the P2SH Address found at the top of "Tickets" page of your Stakepool under the "Ticket Information" section.
+* Your `pooladdress` is the address for your Stakepool's fees are collected. This can be found in the "Ticket Instructions" section of your Stakepool's "Tickets" page.
+* Your `poolfees` is the percentage of the stake reward that will go to the `pooladdress` when a ticket votes. It is important to match your pool's advertised fee. 
+
+A quick example: 
+
+`dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5` would use DCR from your `default` account to purchase 1 ticket if the current ticket price is a max of 23 DCR. The P2SH Address received from the stakepool is `DcExampleAddr1For2Demo3PurposesOnly` and their fee address is `DsExampleAddr1For2Demo3PurposesOnly`. They will collect a 7.5% fee if this ticket successfully votes. This ticket will not expire from the mempool until the ticket price changes, as only 7 arguments were specified (no `expiry`).
+
+---
+
+#### **Ticketbuyer Configuration**
+
+To set up your `dcrwallet` to enable its built-in ticketbuyer feature, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enableticketbuyer=1
+
+If you are using a Stakepool, you should also add the following lines (all of these can be found on your Stakepool's "Tickets" page):
+
+    ticketaddress=<P2SH Address shared with Stakepool>
+    pooladdress=<Stakepool's Fee Collection Address>
+    poolfees=<Stakepool's Required Reward Fee>
+
+You might also want to configure `ticketbuyer`.
+
+`ticketbuyer` will use the following default settings (also found in the chart [below](#full-ticketbuyer-options)) unless they are otherwise specified in your `dcrwallet.conf` file in the `[Ticket Buyer Options]` section:
+
+* **ticketbuyer.avgpricemode=vwap** - ticketbuyer uses a volume weighted average price formula to calculate the average ticket price.
+* **ticketbuyer.avgpricevwapdelta=2880** - ticketbuyer uses the last 2880 tickets in the vwap calculation.
+* **ticketbuyer.maxfee=0.1** - ticketbuyer will never buy a ticket with a fee rate higher than 0.1.
+* **ticketbuyer.minfee=0.01** - ticketbuyer will never buy a ticket with a fee rate lower than 0.01.
+* **ticketbuyer.feesource=median** - ticketbuyer uses a median to calculate fee rate, in which half of fees are higher and half of fees are lower.
+* **ticketbuyer.maxperblock=5** - ticketbuyer will by a maximum of 5 tickets per block if fee and price are within range.
+* **ticketbuyer.blockstoavg=10** - the number of blocks used to calculate the average fee rate.
+* **ticketbuyer.feetargetscaling=1** - ticketbuyer multiplies the average fee by 1 to calculate the fee rate to attempt to use.
+* **ticketbuyer.maxinmempool=40** - ticketbuyer will never allow your mempool tickets to exceed 40.
+* **ticketbuyer.expirydelta=16** - tickets that aren't mined within 16 blocks are refunded to you.
+* **ticketbuyer.maxpricerelative=1.25** - ticketbuyer will never buy a ticket with a ticker price higher than (average price * 1.25).
+* **ticketbuyer.balancetomaintainrelative=0.3** - ticketbuyer will not use more than 70% of your funds to purchase tickets.
+
+A full list of `ticketbuyer` options can be found [below](#full-ticketbuyer-options). There are many variables that can be customized to get `ticketbuyer` to behave exactly how you want. 
+
+With `ticketbuyer` running and your wallet unlocked, you can watch your `dcrwallet` console to see whether or not tickets are being purchased. It will even display an explanation if tickets weren't purchased.
+
+---
+
+## **Full Ticketbuyer Options**
+
+We recommended you read
+and understand the options available before using the feature as you may set your fees and ticket 
+prices higher than desired.
+
+All of these options can be specified on the command line or in dcrwallet.conf. Note that at
+this time there is no way to change settings while dcrwallet is running: you will need to restart it to 
+adjust your settings.
+
+Parameter|Description|Default|Explanation
+:----------:|:---------------------------:|:----------:|:---------------------------:
+ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
+ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
+ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
+ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
+ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
+ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
+ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
+ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
+ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
+ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
+ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
+ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
+ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
+ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
+ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
+ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+
+---

--- a/de_docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/de_docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,12 +1,12 @@
 # **Buying Tickets With dcrwallet**
 
-Last updated for v0.8.2 on 4/18/2017
+Last updated for v0.8.2
 
 This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
 
 **Prerequisites:**
 
-- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Use the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrd`, `dcrwallet,` and `dcrctl`. Additional steps will be required if another installation method was used.
 - Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 - [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
@@ -23,9 +23,9 @@ NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]
 
 There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
 
-Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online at all times (24/7) and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
 
-Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+Solo-voting requires you to have a voting wallet unlocked at all times (24/7), or else you may miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
 
 Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
 

--- a/de_docs/mining/proof-of-stake.md
+++ b/de_docs/mining/proof-of-stake.md
@@ -1,49 +1,88 @@
-# ** Proof-of-Stake (PoS) Mining**
+# **Proof-of-Stake (PoS) Mining**
+
+Last updated for v0.8.2
+
+This document is meant to be an educational resource for Proof-of-Stake mining (staking) with Decred. It will cover the purpose of the Proof-of-Stake protocol, a brief introduction to the staking process, a ticket lifecycle, and get you started with ticket buying. 
 
 ---
 
-## ** Overview **
+## **Overview**
 
-This document explains the process by which one purchases a ticket with DCR by
-sending an SStx transaction.  If the transaction is successfully mined, it will
-then go through a 256 block maturation period.  Once mature, the ticket will be
-randomly selected to vote on PoW blocks as covered by the
-[general mining overview](/mining/proof-of-stake.md).
+Decred's unique Proof-of-Stake protocol serves multiple purposes:
 
----
+To provide a metric for stakeholders/end-user support of any consensus updates. That is, stakeholders are able to vote on specific proposals/agenda on the Decred blockchain. Agendas may include deciding whether or not the dev team spends time implementing a specific feature, activating the code of a feature already submitted for implementation, or making other decisions such as how the dev subsidy should be spent.
 
-## ** Prerequisites **
-
-- A running [dcrd](/getting-started/user-guides/dcrd-setup.md) Instance
-- A running [dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) Instance
-- [dcrctl basics](/getting-started/user-guides/dcrctl-basics.md) such as unlocking your wallet.
-- [Obtain some DCR](/getting-started/obtaining-dcr.md)
+Decred's PoS also provides a system of checks and balances for nonconforming miners. Stakeholders can vote a block invalid if it doesn't match to the consensus rules of the network. 
 
 ---
 
-## ** Solo Mining or Pool Mining **
+## **Staking 101**
 
-> <i class="fa fa-male"></i> Solo Mining
+To participate in proof-of-stake mining, stakeholders lock some DCR in return for a ticket. Every ticket owned gives a stakeholder the ability to cast a single vote. Upon voting, each ticket returns a small reward plus the original **Ticket Price** of the ticket. Each ticket is selected to vote at random, giving an average vote time of 28 days, but possibly requiring up to 142 days, with a .5% chance of expiring before being chosen to vote (this expiration returns the original **Ticket Price** without a reward). Every block mined must include 5 votes (Miners are penalized by a reward deduction if less than 5 votes are included). Every block mined can also include up to 20 fresh ticket purchases. A new ticket requires 256 block to mature before it is entered into the **Ticket Pool* and able to be called upon to vote.
 
-<i class="fa fa-exclamation-triangle"></i> **In order to successfully
-take part in PoS, you need to make sure that your wallet is online 24/7. This
-is because your ticket may be called on to vote at any time and if your wallet
-is unable to respond you will lose the vote reward.  The amount of your ticket
-purchase will be returned minus transaction fees.**
+There are a few important variables that you should familiarize yourself with while staking.
 
-> <i class="fa fa-users"></i> Pool Mining
+Every 144 blocks (~12 hours), the stake difficulty algorithm calculates a new **Ticket Price** in an attempt to keep the **Ticket Pool** size near the target pool size of 40,960 tickets. This 144 block window is referred to as the `StakeDiffWindowSize`.
 
-Using a stake pool is beneficial because the servers are geographically
-distributed and redundant which vastly increases the odds that your vote
-will always be cast even if a network or server outage occurs.
-The stake pools charge a fee to pay for server costs and system
-administration labor.
+The **Ticket Price**/**Stake Difficulty** is the price you must pay for a ticket during a single 144 block window.
+
+The **Ticket Pool** is the total number of tickets in the Decred network.
+
+The **Ticket Fee** (`ticketfee`) is the fee rate that must be included in the ticket purchase to incentivize Proof-of-Work miners to include that ticket in a new block. **Ticket Fee** usually refers to the DCR/kB fee rate for a ticket purchase transaction. Therefore, with a higher transaction size, you will end up paying a higher absolute fee. For example, solo-staking ticket purchases are around 300kB, which means a **Ticket Fee** of .3 DCR/kB will result in the spending on .1 DCR if, and only if, that ticket gets included in a block.
+
+When the **Ticket Price** gets relatively low for a single **Ticket Window**, you can usually expect a fee market to form, with many stakeholders trying to buy tickets before the window ends. When the **Ticket Price** is not at an extremely low and profitable price, the default **Ticket Fee** of 0.01 DCR/kB rate is usually high enough to be included in a block. Keep in mind that 
+
+When a ticket is called to vote, the wallet that has voting rights for that ticket must be online. If the wallet is not online to cast its vote, the ticket will be marked as `missed` and you will not receive a reward for that ticket. Stakepools are offered as a solution for those that cannot have a voting wallet online 24/7.
+
+Stakepools allow stakeholders to generate ticket purchase transactions that give a stakepool voting rights for your ticket. They vote on your behalf, usually requiring a small fee for participation (under 7%) which covers the cost of hosting the minimum of 3 servers required to run a stakepool. This fee is known as the **Pool Fee** and is only taken out of the small PoS reward. A list of stakepools can be found [below](#list-of-stakepools).
 
 ---
 
-## **<i class="fa fa-life-ring"></i> Sign Up For a Stake Pool**
+## **Ticket Lifecycle**
 
-These stake pools are officially recognized:
+Purchasing a ticket for PoS is quite simple (see below) but what happens to it after you buy it?
+A ticket on main net (test net uses different parameters) will go through a few stages in its lifetime:
+
+1. You buy a ticket using a Paymetheus <!--, Decrediton,--> or dcrwallet wallet. The total cost of the each single ticket transaction should be **Ticket Price** + **Ticket Fee**(`ticketfee`).
+2. Your ticket enters the `mempool`. This is where your ticket waits to be mined by PoW miners. Only 20 fresh tickets are mined into each block.
+3. Tickets are mined into a block in with higher **Ticket Fee** transactions having a higher priority. Note that the **Ticket Fee** is DCR per KB of the transaction. A few common transaction sizes are 298kB (a solo ticket purchase) and 539kB (a pool ticket purchase).
+4. **A -** If your ticket is mined into a block, it becomes an immature ticket. This state lasts for 256 blocks (about 20 hours). During this time the ticket cannot vote. At this point, the ticket fee is non-refundable. <br /> 
+**B -** If your ticket is not mined, both the **Ticket Price** and **Ticket Fee** are returned to the purchasing account.
+5. After your ticket matures (256 blocks), it enters the **Ticket Pool** and is eligible for voting.
+6. The chance of a ticket voting is based on a Poisson distribution with a mean of 28 days. After 28 days a ticket has a 50% chance to have already voted.
+7. Given a target pool size of 40960 tickets, any given ticket has a 99.5% chance of voting within ~142 days (about 4.7 months). If, after this time, a ticket has not voted, it expires. You receive a refund on the original **Ticket Price**.
+8. A ticket may miss its call to vote if the voting wallet does not respond or two valid blocks are found within close proximity of each other. If this happens, you receive a refund on the original **Ticket Price**.
+9. After a ticket has voted, missed, or expired, the funds (ticket price and subsidy if applicable, minus the fee) will enter immature status for another 256 blocks, after which they are released. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet which then frees up the locked ticket outputs. **NOTE:** Revocations can only be submitted for a corresponding missed ticket. You cannot revoke a ticket until it is missed.
+
+---
+
+## **How to Stake**
+
+A wallet that is open and unlocked 24/7 is *highly recommended* for staking. Any loss in uptime may result in a loss of vote and reward. Stakepools are available for those unable to keep a personal voting wallet online forever.
+
+The only other requirement for staking is that you buy a ticket. Below you can find guides for buying tickets using [Paymetheus](#paymetheus) and [dcrwallet](#dcrwallet).
+
+If you intend to use a stakepool, you must first sign up for one. Links to officially recognized stakepools are provided [here](#list-of-stakepools).
+
+---
+
+## **Paymetheus**
+
+The Paymetheus application is unable to vote itself, which means that voting rights must be assigned to a stakepool.
+
+Please see the [Purchase Tickets tab guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab) for Paymetheus to learn how to buy tickets using Paymetheus and a stakepool.
+
+---
+
+## **dcrwallet**
+
+The [Buying Tickets with dcrwallet](/getting-started/user-guides/dcrwallet-tickets.md) guide will show you how to buy tickets manually and automatically for pool or solo staking.
+
+---
+
+## **<i class="fa fa-life-ring"></i> List of Stakepools**
+
+These stakepools are officially recognized:
 
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakepool.net](https://dcr.stakepool.net)
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakeminer.com](https://dcr.stakeminer.com)
@@ -56,228 +95,24 @@ These stake pools are officially recognized:
 
 You can find a comparison of each pool's fees and statistics by visiting the
 [<i class="fa fa-external-link-square"></i> Decred website](https://decred.org)
-and clicking the 'Stakepools' link within the footer.
-
-Each pool runs the same software which will walk you through the ticket buying
-process. The instructions are also below so you may view them without signing
-up for a pool.
+and clicking the 'Stakepools' link within the footer at the bottom of the page.
 
 ---
 
-## **<i class="fa fa-ticket"></i> Automatic Purchasing Of Tickets**
+<!-- TODO: **Purchasing Tickets with Decrediton** -->
 
-You can set up dcrwallet to automatically purchase tickets on your behalf. We recommended you read
-and understand the options available before using the feature as you may set your fees and ticket 
-prices higher than desired.
+## **Additional Information**
 
-All of these options can be specified on the command line or in dcrwallet.conf. Note that at
-this time there is no way to change settings while dcrwallet is running. You will need to restart it to 
-adjust your settings.
+[Proof-of-Stake Commands](/advanced/program-options.md#pos-commands)
 
-Parameter|Description|Default|Explanation
-:----------:|:---------------------------:|:----------:|:---------------------------:
-ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
-ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
-ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
-ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
-ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
-ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
-ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
-ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
-ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
-ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
-ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
-ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
-ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
-ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
-ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
-ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+[Proof-of-Stake FAQ - General](/faq/proof-of-stake/general.md)
 
----
+[Proof-of-Stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
 
-## **<i class="fa fa-ticket"></i> Manual Purchasing Of Tickets**
+[Proof-of-Stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
 
-> Obtaining Ticket Price and Block Height
+[Proof-of-Stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
 
-First, get the current ticket price from the **difficulty** field from **getstakeinfo**:
+[Proof-of-Stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
 
-```no-highlight
-dcrctl --wallet getstakeinfo
-{
-  "poolsize": 42670,
-  "difficulty": 22.07045882,
-  "allmempooltix": 0,
-  "ownmempooltix": 0,
-  "immature": 0,
-  "live": 0,
-  "proportionlive": 0,
-  "voted": 0,
-  "totalsubsidy": 0,
-  "missed": 0,
-  "proportionmissed": 0,
-  "revoked": 0
-}
-```
-
-It is also helpful to get the **height** field from **getbestblock** so you may
-use the ticket expiration functionality:
-
-```no-highlight
-dcrctl --wallet getblockheight
-{
-  "hash": "0000000000000d14cab9056131a0461778a7f8cd1066cb343307882bd730f2a9",
-  "height": 35472
-}
-```
-
-Getting this information directly is the most reliable and accurate but you may
-also use the official stats page at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org).
-
-> Purchaseticket Syntax
-
-Now purchase your ticket(s) via dcrctl.  The full syntax for the command is:
-
-```no-highlight
-dcrctl --wallet help purchaseticket
-purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
-
-Purchase ticket using available funds.
-
-Arguments:
-1. fromaccount   (string, required)             The account to use for purchase (default="default")
-2. spendlimit    (numeric, required)            Limit on the amount to spend on ticket
-3. minconf       (numeric, optional, default=1) Minimum number of block confirmations required
-4. ticketaddress (string, optional)             Override the ticket address to which voting rights are given
-5. numtickets    (numeric, optional)            The number of tickets to purchase
-6. pooladdress   (string, optional)             The address to pay stake pool fees to
-7. poolfees      (numeric, optional)            The amount of fees to pay to the stake pool
-8. expiry        (numeric, optional)            Height at which the purchase tickets expire
-9. comment       (string, optional)             Unused
-
-Result:
-"value" (string) Hash of the resulting ticket
-```
-
-> Manual Ticket Purchasing Example (Solo)
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 "" 1 "" 0.0 35482
-```
-
-This purchases one ticket from the default account for a maximum of 23 DCR that
-expires at block 35482.
-
-The command will return a ticket hash / transaction id if successful.
-
-> dcrwallet Manual Ticket Purchasing Example (Pool)
-
-The ticket purchasing part for a pool is much the same but there are some more
-steps involved to allow both you and the pool to vote by creating a
-multisignature script and P2SH address.
-
-Once you sign up for a stake pool, you will be redirected to an address
-submission page.
-
-To join the pool, provide a public key address which can be used to generate a
-1-of-2 multisignature script. The multisignature script will be generated by
-the pool and returned to you along with a P2SH address to give voting rights to.
-The P2SH address starts with **Dc** on mainnet.
-
-It is recommended to generate a new account when joining a stake pool.  This is
-because accounts are hardened so in the case of a total stake pool
-failure/shutdown, it would be safe to give the private key to another stake pool
-as long as that account only does voting and nothing else.
-
-```no-highlight
-dcrctl --wallet createnewaccount voting
-```
-
-To generate a public key address, create a new wallet address with **getnewaddress &lt;account&gt;**.
-Then, call **validateaddress &lt;yourAddress&gt;** and retrieve the address listed in the
-**pubkeyaddr** field of the response. It is prefixed with **Dk** on mainnet.
-
-The following is an example for mainnet:
-
-```no-highlight
-dcrctl --wallet getnewaddress voting
-DsExampleAddr1For2Demo3PurposesOnly
-dcrctl --wallet validateaddress DsExampleAddr1For2Demo3PurposesOnly
-{
-  "isvalid": true,
-  "address": "DsExampleAddr1For2Demo3PurposesOnly",
-  "ismine": true,
-  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
-  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
-  "iscompressed": true,
-  "account": "voting"
-}
-```
-
-Copy and paste the **pubkeyaddr** into the stake pool's submit address form
-and click the submit button.  Your multisig script and P2SH address will be
-generated and you will be redirected to the tickets page.
-
-Now simply follow the directions on the tickets page. First, import the
-multisig script locally into your wallet using dcrctl for safe keeping,
-so you can recover your funds and vote in the unlikely event of a pool
-failure:
-
-```no-highlight
-dcrctl --wallet importscript <ReallyLongScriptDisplayedOnPoolPage>
-```
-
-Now **purchaseticket** with the stake pool-specific fields set:
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5 35482
-```
-
-This purchases one ticket which is delegated to the P2SH address from the default
-account for a maximum of 23 DCR that expires at block 35482 and pays a 7.5% fee
-to the pool's payment address.
-
-> Paymetheus Manual Ticket Purchasing Example (Pool)
-
-Please see the [Using Paymetheus guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab)
----
-
-## ** Post Purchase Information **
-
-After a successful ticket purchase, you must wait to see whether or not the
-transaction is mined and included in a block.  The main reason for your ticket
-not being mined is that the ticket price adjusts before it can be mined.  This
-can happen due to the mempool being full of competing ticket purchase
-transactions or simply bad purchase timing.  You can use the official Decred stats site at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org) to view when the next ticket price adjustment occurs.
-
-Some other details to keep in mind are:
-
-* The ticket price is not spent, although it is removed from your balance as it is not spendable. It is just a deposit. You will get it back when your ticket votes, expires, or is revoked due to not voting.
-* 20 tickets are accepted into the voting pool each block. Tickets that are waiting stay in the mempool. Tickets are moved from the mempool to the voting pool in order of txfee.
-* Tickets take 256 blocks (about a day) to mature. During this time the stake price you paid will not be visible in your total balance.
-* You can keep track of your tickets' status by periodically running:
-
-```no-highlight
-dcrctl --wallet getstakeinfo
-```
-
-  or by inspecting the Stake Mining tab in Paymetheus.
-
-Continue to [PoS Tickets and Fees FAQ](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
----
-
-## ** <i class="fa fa-book"></i> See Also **
-
-[Proof-of-stake Commands](/advanced/program-options.md#pos-commands)
-
-[Proof-of-stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
-[Proof-of-stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
-
-[Proof-of-stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
-
-[Proof-of-stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
-
-[Proof-of-stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)
+[Proof-of-Stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)

--- a/de_mkdocs.yml
+++ b/de_mkdocs.yml
@@ -30,6 +30,7 @@ pages:
     - 'dcrd Setup': 'getting-started/user-guides/dcrd-setup.md'
     - 'dcrwallet Setup': 'getting-started/user-guides/dcrwallet-setup.md'
     - 'dcrctl Basics': 'getting-started/user-guides/dcrctl-basics.md'
+    - 'Buying Tickets': 'getting-started/user-guides/dcrwallet-tickets.md'
   - 'Web Wallet': 'getting-started/user-guides/web.md'
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'

--- a/docs/getting-started/user-guides/dcrctl-basics.md
+++ b/docs/getting-started/user-guides/dcrctl-basics.md
@@ -2,7 +2,7 @@
 
 Last updated for v0.8.2.
 
-This guide is intended to help you learn the basic commands of the `dcrctl` application using [startup flags](/getting-started/startup-basics.md#startup-command-flags). 
+This guide is intended to help you learn the basic commands of the `dcrctl` application using a [minimal configuration file](/getting-started/startup-basics.md#minimum-configuration). 
 
 **Prerequisites:**
 

--- a/docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,0 +1,208 @@
+# **Buying Tickets With dcrwallet**
+
+Last updated for v0.8.2 on 4/18/2017
+
+This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
+
+**Prerequisites:**
+
+- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
+- [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
+- Familiarize yourself with the [basics of using dcrctl](/getting-started/user-guides/dcrctl-basics.md).
+- Familiarize yourself with the [staking process](/mining/proof-of-stake.md#staking-101) and the [ticket lifecycle](/mining/proof-of-stake.md#ticket-lifecycle)
+
+This guide assumes you have set up `dcrd` and `dcrwallet` using configuration files. If you used `dcrinstall`, you have configuration files already. Using configuration files is highly recommended - it makes for an easier time issuing commands to `dcrwallet` and `dcrd` through `dcrctl`. A guide for minimum configuration (saving your RPC username and RPC password) can be found [here](/getting-started/startup-basics.md#minimum-configuration). 
+
+NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]` and `[Ticket Buyer Options]`. Any setting prefixed by 'tickeybuyer.' must be placed within the lower `[Ticket Buyer Options]` section. All other settings go within `[Application Options]`. 
+
+---
+
+## **Decisions**
+
+There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
+
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+
+Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+
+Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
+
+---
+
+## **Solo-voting**
+
+REMINDER: Solo-voting with a voting wallet that doesn't stay online 24/7 may result in missed votes and forfeited stake rewards.
+
+To solo-vote, you simply set the enablevoting option when starting `dcrwallet`, unlock the wallet with your private passphrase, and buy tickets. With enablevoting enabled and `dcrwallet` unlocked, your wallet will automatically handle voting.
+
+To set up your `dcrwallet` for solo-staking, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enablevoting=1
+
+Once restarted with that line in `dcrwallet.conf` your wallet will be configured for solo-voting and you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Stakepool-voting**
+
+To allow a stakepool to vote for you, you first have to sign up for a stakepool. A list of them can be found [here](/mining/proof-of-stake.md#list-of-stakepools). After signing up, there should be directions for creating a new P2SH address and importing your multi-sig voting script. A brief overview is provided here:
+
+1. With your wallet open, issue the `dcrctl --wallet getnewaddress` command to retrieve an address.
+2. Using that address, issue the `dcrctl --wallet validateaddress <address from step 1>` command. This should return a JSON object that will be displayed like so:
+```
+{
+  "isvalid": true,
+  "address": "DsExampleAddr1For2Demo3PurposesOnly",
+  "ismine": true,
+  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
+  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
+  "iscompressed": true,
+  "account": "voting"
+}
+```
+3. Copy the `pubkeyaddr` into the stakepool's "Submit Address" form and hit the submit button. The page should redirect you to the tickets page, which will display more instructions.
+4. At the top of the tickets page, you should see a "Ticket Information" section. Copy your "Redeem Script" and use it to issue the `dcrctl --wallet importscript <Insert Redeem Script Here>` command.
+
+With the stakepool configured and your multi-sig script imported to your wallet, you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Ticket Purchasing**
+
+Both manual and automatic ticket purchasing require your wallet to be unlocked via the `dcrcrl --wallet walletpassphrase <private passphrase> <time limit>` command.
+
+There are three things you might want to understand before purchasing tickets: the `purchaseticket` command, when/why a `ticketfee` is important, and the significance of `ticket price`.
+
+> purchaseticket Command
+
+The `purchaseticket` command will be used to purchase tickets whether manual or automatic. Let's take a closer look at the command and its arguments:
+
+```
+purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
+```
+
+1. `fromaccount`    =  Required String: The account from which to purchase tickets (e.g. "default").
+2. `spendlimit`     =  Required Number: Limit on the amount to spend on ticket (e.g. 50).
+3. `minconf`        =  Optional Number: Minimum number of block confirmations required (e.g. 1).
+4. `ticketaddress`  =  Optional String: The ticket address to which voting rights are given
+5. `numtickets`     =  Optional Number: The number of tickets to purchase at once (e.g. 1)
+6. `pooladdress`    =  Optional String: The address to pay stake pool fees to
+7. `poolfees`       =  Optional Number: The percentage of fees to pay to the stake pool (e.g. 5)
+8. `expiry`         =  Optional Number: The block height where unmined tickets will expire from the mempool, returning the original DCR to your "fromaccount". If left blank, tickets will only expire in the mempool when the ticket price changes.
+9. `comment`        =  Optional String: This argument is unused and has no significance. 
+
+> Ticket Fees
+
+Your `ticketfee` is the DCR/kB rate you'll pay to have your ticket purchase be included in a block by a miner. You'll notice that the above ticketpurchase command doesn't include any `ticketfee` arguments. The `ticketfee` argument can be set two ways.
+
+1. During startup by adding `ticketfee=<fee rate>` to the `[Application Options]` of your `dcrwallet.conf`.
+2. While your wallet is running, using the `dcrctl --wallet setticketfee <fee rate>` command. This is not a permanent setting and will default to 0.01 every time your wallet is restarted unless a ticketfee is specified in `dcrwallet.conf`.
+
+Why are ticketfees important? Usually the default fee of 0.01 is enough to get your tickets mined. The exception is during a fee war event. When the ticket price falls very low, demand outpaces supply (there are only a maximum of 2880 tickets available at each price interval). This creates a fee war, with stakeholders competing to get their tickets mined before the price changes.
+
+With these two things in mind, let's continue to the two methods for purchasing tickets.
+
+> Ticket Price
+
+To get the current ticket price, issue the `dcrctl --wallet getstakeinfo` command and look for the `difficulty` value. This is the price of each ticket in the current price window. You'll want to adjust your `spendlimit` argument in the `purchaseticket` command to be greater than this `difficulty` value when purchasing tickets manually.
+
+--- 
+
+#### **Manual Ticket Purchase**
+
+Before manually purchasing tickets, it is recommended to check for a ticketfee war and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command. Third party sites such as https://dcrstats.com and https://posmaster.info can be used to find the average ticketfee in the mempool, although you may oftentimes be able to purchase a ticket with a ticketfee lower than the average.
+
+> Solo Tickets
+
+To purchase tickets used for solo-staking, you only need to specify the `fromaccount` and `spendlimit` arguments while using the `purchaseticket` command. For example: `dcrctl --wallet purchaseticket "default" 50` would use DCR from your `default` account to purchase a ticket if the current ticket price was a max of 50 DCR.
+
+If you wish to specify the `numticket` or `expiry` arguments, you would specify a `minconf` of 1, an empty `ticketaddress` (""), an empty `pooladdress` (""), and an empty `poolfees` (0). Two example follow:
+
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5` would purchase 5 tickets, as the 5th argument (`numtickets`) is set to 5.
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5 "" 0 100000` would purchase 5 tickets that would expire from the mempool if not mined by block 100,000, as the 8th argument (`expiry`) is set to 100000.
+ 
+Be sure to check for a fee war event and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command.
+
+> Pool Tickets
+
+To purchase tickets with their voting rights delegated to a stakepool, we have to use the full `purchaseticket` command.
+
+* Your `ticketaddress` is the P2SH Address found at the top of "Tickets" page of your Stakepool under the "Ticket Information" section.
+* Your `pooladdress` is the address for your Stakepool's fees are collected. This can be found in the "Ticket Instructions" section of your Stakepool's "Tickets" page.
+* Your `poolfees` is the percentage of the stake reward that will go to the `pooladdress` when a ticket votes. It is important to match your pool's advertised fee. 
+
+A quick example: 
+
+`dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5` would use DCR from your `default` account to purchase 1 ticket if the current ticket price is a max of 23 DCR. The P2SH Address received from the stakepool is `DcExampleAddr1For2Demo3PurposesOnly` and their fee address is `DsExampleAddr1For2Demo3PurposesOnly`. They will collect a 7.5% fee if this ticket successfully votes. This ticket will not expire from the mempool until the ticket price changes, as only 7 arguments were specified (no `expiry`).
+
+---
+
+#### **Ticketbuyer Configuration**
+
+To set up your `dcrwallet` to enable its built-in ticketbuyer feature, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enableticketbuyer=1
+
+If you are using a Stakepool, you should also add the following lines (all of these can be found on your Stakepool's "Tickets" page):
+
+    ticketaddress=<P2SH Address shared with Stakepool>
+    pooladdress=<Stakepool's Fee Collection Address>
+    poolfees=<Stakepool's Required Reward Fee>
+
+You might also want to configure `ticketbuyer`.
+
+`ticketbuyer` will use the following default settings (also found in the chart [below](#full-ticketbuyer-options)) unless they are otherwise specified in your `dcrwallet.conf` file in the `[Ticket Buyer Options]` section:
+
+* **ticketbuyer.avgpricemode=vwap** - ticketbuyer uses a volume weighted average price formula to calculate the average ticket price.
+* **ticketbuyer.avgpricevwapdelta=2880** - ticketbuyer uses the last 2880 tickets in the vwap calculation.
+* **ticketbuyer.maxfee=0.1** - ticketbuyer will never buy a ticket with a fee rate higher than 0.1.
+* **ticketbuyer.minfee=0.01** - ticketbuyer will never buy a ticket with a fee rate lower than 0.01.
+* **ticketbuyer.feesource=median** - ticketbuyer uses a median to calculate fee rate, in which half of fees are higher and half of fees are lower.
+* **ticketbuyer.maxperblock=5** - ticketbuyer will by a maximum of 5 tickets per block if fee and price are within range.
+* **ticketbuyer.blockstoavg=10** - the number of blocks used to calculate the average fee rate.
+* **ticketbuyer.feetargetscaling=1** - ticketbuyer multiplies the average fee by 1 to calculate the fee rate to attempt to use.
+* **ticketbuyer.maxinmempool=40** - ticketbuyer will never allow your mempool tickets to exceed 40.
+* **ticketbuyer.expirydelta=16** - tickets that aren't mined within 16 blocks are refunded to you.
+* **ticketbuyer.maxpricerelative=1.25** - ticketbuyer will never buy a ticket with a ticker price higher than (average price * 1.25).
+* **ticketbuyer.balancetomaintainrelative=0.3** - ticketbuyer will not use more than 70% of your funds to purchase tickets.
+
+A full list of `ticketbuyer` options can be found [below](#full-ticketbuyer-options). There are many variables that can be customized to get `ticketbuyer` to behave exactly how you want. 
+
+With `ticketbuyer` running and your wallet unlocked, you can watch your `dcrwallet` console to see whether or not tickets are being purchased. It will even display an explanation if tickets weren't purchased.
+
+---
+
+## **Full Ticketbuyer Options**
+
+We recommended you read
+and understand the options available before using the feature as you may set your fees and ticket 
+prices higher than desired.
+
+All of these options can be specified on the command line or in dcrwallet.conf. Note that at
+this time there is no way to change settings while dcrwallet is running: you will need to restart it to 
+adjust your settings.
+
+Parameter|Description|Default|Explanation
+:----------:|:---------------------------:|:----------:|:---------------------------:
+ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
+ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
+ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
+ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
+ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
+ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
+ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
+ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
+ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
+ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
+ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
+ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
+ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
+ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
+ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
+ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+
+---

--- a/docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,12 +1,12 @@
 # **Buying Tickets With dcrwallet**
 
-Last updated for v0.8.2 on 4/18/2017
+Last updated for v0.8.2
 
 This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
 
 **Prerequisites:**
 
-- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Use the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrd`, `dcrwallet,` and `dcrctl`. Additional steps will be required if another installation method was used.
 - Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 - [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
@@ -23,9 +23,9 @@ NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]
 
 There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
 
-Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online at all times (24/7) and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
 
-Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+Solo-voting requires you to have a voting wallet unlocked at all times (24/7), or else you may miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
 
 Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
 

--- a/docs/mining/proof-of-stake.md
+++ b/docs/mining/proof-of-stake.md
@@ -1,98 +1,88 @@
-# ** Proof-of-Stake (PoS) Mining**
+# **Proof-of-Stake (PoS) Mining**
+
+Last updated v0.8.2 - April 11, 2017
+
+This document is meant to be an educational resource for Proof-of-Stake mining (staking) with Decred. It will cover the purpose of the Proof-of-Stake protocol, a brief introduction to the staking process, a ticket lifecycle, and get you started with ticket buying. 
 
 ---
 
-## ** Overview **
+## **Overview**
 
-Proof of Stake mining is the second method of block verification in Decred. It
-is computationally cheap but it requires you to already have some DCR in your
-wallet. In the Decred network, PoW miners solve blocks then turn those blocks
-over to PoS miners to vote on them. When a block is completed, 5 tickets are
-chosen at random from the ticket pool to vote on the block. If at least 3 votes
-are ‘Yes' then the block is validated, included in the block chain and both
-PoW and PoS miners are paid. If the vote fails, the block is discarded and the
-transactions return to be included in another block. The PoW miners are not
-paid, however the PoS miners are.
+Decred's unique Proof-of-Stake protocol serves multiple purposes:
 
-This is to incentivize PoW miners to mine according to the wishes of PoS
-miners. For example, if the rules of the network change in the future any
-PoW miners who don't follow them will not be paid. It also helps stop large
-mining pools getting too much influence over the network. In
-cryptocurrencies that don't use PoS, the large groups of PoW miners who
-effectively control the network can collude to block transactions, stop network
-changes or even force faked transactions (although this would take a huge
-amount of resources). Collusion between PoW and PoS miners is not possible as
-tickets are not chosen until the time of the vote. Collusion between PoS miners
-is likewise remote as the ticket pool is kept at around 40,960 active tickets
-at any time. The chance of three tickets belonging to the same individual or
-group being chosen for the same block is very small. Even if this did happen
-every transaction is validated at least twice so the chance of anyone
-manipulating the blockchain is effectively zero.
+To provide a metric for stakeholders/end-user support of any consensus updates. That is, stakeholders are able to vote on specific proposals/agenda on the Decred blockchain. Agendas may include deciding whether or not the dev team spends time implementing a specific feature, activating the code of a feature already submitted for implementation, or making other decisions such as how the dev subsidy should be spent.
 
-
-This document explains the process by which one purchases a ticket with DCR by
-sending an SStx transaction.  If the transaction is successfully mined, it will
-then go through a 256 block maturation period.  Once mature, the ticket will be
-randomly selected to vote on PoW blocks as covered by the
-[general mining overview](/mining/proof-of-stake.md).
+Decred's PoS also provides a system of checks and balances for nonconforming miners. Stakeholders can vote a block invalid if it doesn't match to the consensus rules of the network. 
 
 ---
 
-## ** Prerequisites **
+## **Staking 101**
 
-- A running [dcrd](/getting-started/user-guides/dcrd-setup.md) Instance
-- A running [dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) Instance
-- [dcrctl basics](/getting-started/user-guides/dcrctl-basics.md) such as unlocking your wallet.
-- [Obtain some DCR](/getting-started/obtaining-dcr.md)
+To participate in proof-of-stake mining, stakeholders lock some DCR in return for a ticket. Every ticket owned gives a stakeholder the ability to cast a single vote. Upon voting, each ticket returns a small reward plus the original **Ticket Price** of the ticket. Each ticket is selected to vote at random, giving an average vote time of 28 days, but possibly requiring up to 142 days, with a .5% chance of expiring before being chosen to vote (this expiration returns the original **Ticket Price** without a reward). Every block mined must include 5 votes (Miners are penalized by a reward deduction if less than 5 votes are included). Every block mined can also include up to 20 fresh ticket purchases. A new ticket requires 256 block to mature before it is entered into the **Ticket Pool* and able to be called upon to vote.
+
+There are a few important variables that you should familiarize yourself with while staking.
+
+Every 144 blocks (~12 hours), the stake difficulty algorithm calculates a new **Ticket Price** in an attempt to keep the **Ticket Pool** size near the target pool size of 40,960 tickets. This 144 block window is referred to as the `StakeDiffWindowSize`.
+
+The **Ticket Price**/**Stake Difficulty** is the price you must pay for a ticket during a single 144 block window.
+
+The **Ticket Pool** is the total number of tickets in the Decred network.
+
+The **Ticket Fee** (`ticketfee`) is the fee rate that must be included in the ticket purchase to incentivize Proof-of-Work miners to include that ticket in a new block. **Ticket Fee** usually refers to the DCR/kB fee rate for a ticket purchase transaction. Therefore, with a higher transaction size, you will end up paying a higher absolute fee. For example, solo-staking ticket purchases are around 300kB, which means a **Ticket Fee** of .3 DCR/kB will result in the spending on .1 DCR if, and only if, that ticket gets included in a block.
+
+When the **Ticket Price** gets relatively low for a single **Ticket Window**, you can usually expect a fee market to form, with many stakeholders trying to buy tickets before the window ends. When the **Ticket Price** is not at an extremely low and profitable price, the default **Ticket Fee** of 0.01 DCR/kB rate is usually high enough to be included in a block. Keep in mind that 
+
+When a ticket is called to vote, the wallet that has voting rights for that ticket must be online. If the wallet is not online to cast its vote, the ticket will be marked as `missed` and you will not receive a reward for that ticket. Stakepools are offered as a solution for those that cannot have a voting wallet online 24/7.
+
+Stakepools allow stakeholders to generate ticket purchase transactions that give a stakepool voting rights for your ticket. They vote on your behalf, usually requiring a small fee for participation (under 7%) which covers the cost of hosting the minimum of 3 servers required to run a stakepool. This fee is known as the **Pool Fee** and is only taken out of the small PoS reward. A list of stakepools can be found [below](#list-of-stakepools).
 
 ---
 
-## ** How Does It Work? ** ##
+## **Ticket Lifecycle**
 
 Purchasing a ticket for PoS is quite simple (see below) but what happens to it after you buy it?
 A ticket on main net (test net uses different parameters) will go through a few stages in its lifetime:
 
-1. You buy a ticket using your wallet.
-2. The ticket enters the 'mempool'. Only 20 tickets are mined into each block. This is where tickets wait to be mined.
-3. Tickets are mined into a block in order of their `ticketfee`. Note that the ticketfee is priced per KB. 
-A ticket transaction is about a third (solo) or half (pool) a KB so the actual fee you pay will be scaled accordingly.
-4. **A -** If your ticket is mined into a block, it will enter immature status for 256 blocks (about 20 hours). During
-this time the ticket cannot vote. At this point, the ticket fee is non-refundable.  
-**B -** If your ticket is not mined, both the ticket price and fee are returned.
-5. After the ticket matures (256 blocks), your ticket enters the ticket pool and is eligible for voting.
-6. The chance of a ticket voting is based on a Poisson distribution with a mean of 28 days. What this means is that after 28 days any
-ticket has a 50% chance to have already voted.
-7. Given a target pool size of 40960 tickets, any given ticket has a 99.5% chance of voting within ~142 days (about 4.7 months). If,
-after this time, a ticket has not voted, it expires. The ticket price is returned to the user.
-8. A ticket may be missed if the voting wallet does not respond or two valid blocks are found within close proximity of each other.
-If this happens, the ticket price is returned to the user.
-9. After a ticket has voted, missed, or expired, the funds (ticket price and subsidy if applicable, minus the fee) will enter immature status for another 256 blocks, after which they are released. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet which then frees up the locked ticket outputs. *NOTE* Revocations can only be submitted for a corresponding missed ticket. You cannot revoke a ticket until it is missed.
+1. You buy a ticket using a Paymetheus <!--, Decrediton,--> or dcrwallet wallet. The total cost of the each single ticket transaction should be **Ticket Price** + **Ticket Fee**(`ticketfee`).
+2. Your ticket enters the `mempool`. This is where your ticket waits to be mined by PoW miners. Only 20 fresh tickets are mined into each block.
+3. Tickets are mined into a block in with higher **Ticket Fee** transactions having a higher priority. Note that the **Ticket Fee** is DCR per KB of the transaction. A few common transaction sizes are 298kB (a solo ticket purchase) and 539kB (a pool ticket purchase).
+4. **A -** If your ticket is mined into a block, it becomes an immature ticket. This state lasts for 256 blocks (about 20 hours). During this time the ticket cannot vote. At this point, the ticket fee is non-refundable. <br /> 
+**B -** If your ticket is not mined, both the **Ticket Price** and **Ticket Fee** are returned to the purchasing account.
+5. After your ticket matures (256 blocks), it enters the **Ticket Pool** and is eligible for voting.
+6. The chance of a ticket voting is based on a Poisson distribution with a mean of 28 days. After 28 days a ticket has a 50% chance to have already voted.
+7. Given a target pool size of 40960 tickets, any given ticket has a 99.5% chance of voting within ~142 days (about 4.7 months). If, after this time, a ticket has not voted, it expires. You receive a refund on the original **Ticket Price**.
+8. A ticket may miss its call to vote if the voting wallet does not respond or two valid blocks are found within close proximity of each other. If this happens, you receive a refund on the original **Ticket Price**.
+9. After a ticket has voted, missed, or expired, the funds (ticket price and subsidy if applicable, minus the fee) will enter immature status for another 256 blocks, after which they are released. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet which then frees up the locked ticket outputs. **NOTE:** Revocations can only be submitted for a corresponding missed ticket. You cannot revoke a ticket until it is missed.
 
 ---
 
-## ** Solo Mining or Pool Mining **
+## **How to Stake**
 
-> <i class="fa fa-male"></i> Solo Mining
+A wallet that is open and unlocked 24/7 is *highly recommended* for staking. Any loss in uptime may result in a loss of vote and reward. Stakepools are available for those unable to keep a personal voting wallet online forever.
 
-<i class="fa fa-exclamation-triangle"></i> **In order to successfully
-take part in PoS, you need to make sure that your wallet is online 24/7. This
-is because your ticket may be called on to vote at any time and if your wallet
-is unable to respond you will lose the vote reward.  The amount of your ticket
-purchase will be returned minus transaction fees.**
+The only other requirement for staking is that you buy a ticket. Below you can find guides for buying tickets using [Paymetheus](#paymetheus) and [dcrwallet](#dcrwallet).
 
-> <i class="fa fa-users"></i> Pool Mining
-
-Using a stake pool is beneficial because the servers are geographically
-distributed and redundant which vastly increases the odds that your vote
-will always be cast even if a network or server outage occurs.
-The stake pools charge a fee to pay for server costs and system
-administration labor.
+If you intend to use a stakepool, you must first sign up for one. Links to officially recognized stakepools are provided [here](#list-of-stakepools).
 
 ---
 
-## **<i class="fa fa-life-ring"></i> Sign Up For a Stake Pool**
+## **Paymetheus**
 
-These stake pools are officially recognized:
+The Paymetheus application is unable to vote itself, which means that voting rights must be assigned to a stakepool.
+
+Please see the [Purchase Tickets tab guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab) for Paymetheus to learn how to buy tickets using Paymetheus and a stakepool.
+
+---
+
+## **dcrwallet**
+
+The [Buying Tickets with dcrwallet](/getting-started/user-guides/dcrwallet-tickets.md) guide will show you how to buy tickets manually and automatically for pool or solo staking.
+
+---
+
+## **<i class="fa fa-life-ring"></i> List of Stakepools**
+
+These stakepools are officially recognized:
 
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakepool.net](https://dcr.stakepool.net)
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakeminer.com](https://dcr.stakeminer.com)
@@ -105,228 +95,24 @@ These stake pools are officially recognized:
 
 You can find a comparison of each pool's fees and statistics by visiting the
 [<i class="fa fa-external-link-square"></i> Decred website](https://decred.org)
-and clicking the 'Stakepools' link within the footer.
-
-Each pool runs the same software which will walk you through the ticket buying
-process. The instructions are also below so you may view them without signing
-up for a pool.
+and clicking the 'Stakepools' link within the footer at the bottom of the page.
 
 ---
 
-## **<i class="fa fa-ticket"></i> Automatic Purchasing Of Tickets**
+<!-- TODO: **Purchasing Tickets with Decrediton** -->
 
-You can set up dcrwallet to automatically purchase tickets on your behalf. We recommended you read
-and understand the options available before using the feature as you may set your fees and ticket 
-prices higher than desired.
+## **Additional Information**
 
-All of these options can be specified on the command line or in dcrwallet.conf. Note that at
-this time there is no way to change settings while dcrwallet is running. You will need to restart it to 
-adjust your settings.
+[Proof-of-Stake Commands](/advanced/program-options.md#pos-commands)
 
-Parameter|Description|Default|Explanation
-:----------:|:---------------------------:|:----------:|:---------------------------:
-ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
-ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
-ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
-ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
-ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
-ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
-ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
-ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
-ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
-ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
-ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
-ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
-ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
-ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
-ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
-ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+[Proof-of-Stake FAQ - General](/faq/proof-of-stake/general.md)
 
----
+[Proof-of-Stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
 
-## **<i class="fa fa-ticket"></i> Manual Purchasing Of Tickets**
+[Proof-of-Stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
 
-> Obtaining Ticket Price and Block Height
+[Proof-of-Stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
 
-First, get the current ticket price from the **difficulty** field from **getstakeinfo**:
+[Proof-of-Stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
 
-```no-highlight
-dcrctl --wallet getstakeinfo
-{
-  "poolsize": 42670,
-  "difficulty": 22.07045882,
-  "allmempooltix": 0,
-  "ownmempooltix": 0,
-  "immature": 0,
-  "live": 0,
-  "proportionlive": 0,
-  "voted": 0,
-  "totalsubsidy": 0,
-  "missed": 0,
-  "proportionmissed": 0,
-  "revoked": 0
-}
-```
-
-It is also helpful to get the **height** field from **getbestblock** so you may
-use the ticket expiration functionality:
-
-```no-highlight
-dcrctl --wallet getbestblock
-{
-  "hash": "0000000000000d14cab9056131a0461778a7f8cd1066cb343307882bd730f2a9",
-  "height": 35472
-}
-```
-
-Getting this information directly is the most reliable and accurate but you may
-also use the official stats page at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org).
-
-> Purchaseticket Syntax
-
-Now purchase your ticket(s) via dcrctl.  The full syntax for the command is:
-
-```no-highlight
-dcrctl --wallet help purchaseticket
-purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
-
-Purchase ticket using available funds.
-
-Arguments:
-1. fromaccount   (string, required)             The account to use for purchase (default="default")
-2. spendlimit    (numeric, required)            Limit on the amount to spend on ticket
-3. minconf       (numeric, optional, default=1) Minimum number of block confirmations required
-4. ticketaddress (string, optional)             Override the ticket address to which voting rights are given
-5. numtickets    (numeric, optional)            The number of tickets to purchase
-6. pooladdress   (string, optional)             The address to pay stake pool fees to
-7. poolfees      (numeric, optional)            The amount of fees to pay to the stake pool
-8. expiry        (numeric, optional)            Height at which the purchase tickets expire
-9. comment       (string, optional)             Unused
-
-Result:
-"value" (string) Hash of the resulting ticket
-```
-
-> Manual Ticket Purchasing Example (Solo)
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 "" 1 "" 0.0 35482
-```
-
-This purchases one ticket from the default account for a maximum of 23 DCR that
-expires at block 35482.
-
-The command will return a ticket hash / transaction id if successful.
-
-> dcrwallet Manual Ticket Purchasing Example (Pool)
-
-The ticket purchasing part for a pool is much the same but there are some more
-steps involved to allow both you and the pool to vote by creating a
-multisignature script and P2SH address.
-
-Once you sign up for a stake pool, you will be redirected to an address
-submission page.
-
-To join the pool, provide a public key address which can be used to generate a
-1-of-2 multisignature script. The multisignature script will be generated by
-the pool and returned to you along with a P2SH address to give voting rights to.
-The P2SH address starts with **Dc** on mainnet.
-
-It is recommended to generate a new account when joining a stake pool.  This is
-because accounts are hardened so in the case of a total stake pool
-failure/shutdown, it would be safe to give the private key to another stake pool
-as long as that account only does voting and nothing else.
-
-```no-highlight
-dcrctl --wallet createnewaccount voting
-```
-
-To generate a public key address, create a new wallet address with **getnewaddress &lt;account&gt;**.
-Then, call **validateaddress &lt;yourAddress&gt;** and retrieve the address listed in the
-**pubkeyaddr** field of the response. It is prefixed with **Dk** on mainnet.
-
-The following is an example for mainnet:
-
-```no-highlight
-dcrctl --wallet getnewaddress voting
-DsExampleAddr1For2Demo3PurposesOnly
-dcrctl --wallet validateaddress DsExampleAddr1For2Demo3PurposesOnly
-{
-  "isvalid": true,
-  "address": "DsExampleAddr1For2Demo3PurposesOnly",
-  "ismine": true,
-  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
-  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
-  "iscompressed": true,
-  "account": "voting"
-}
-```
-
-Copy and paste the **pubkeyaddr** into the stake pool's submit address form
-and click the submit button.  Your multisig script and P2SH address will be
-generated and you will be redirected to the tickets page.
-
-Now simply follow the directions on the tickets page. First, import the
-multisig script locally into your wallet using dcrctl for safe keeping,
-so you can recover your funds and vote in the unlikely event of a pool
-failure:
-
-```no-highlight
-dcrctl --wallet importscript <ReallyLongScriptDisplayedOnPoolPage>
-```
-
-Now **purchaseticket** with the stake pool-specific fields set:
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5 35482
-```
-
-This purchases one ticket which is delegated to the P2SH address from the default
-account for a maximum of 23 DCR that expires at block 35482 and pays a 7.5% fee
-to the pool's payment address.
-
-> Paymetheus Manual Ticket Purchasing Example (Pool)
-
-Please see the [Using Paymetheus guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab)
----
-
-## ** Post Purchase Information **
-
-After a successful ticket purchase, you must wait to see whether or not the
-transaction is mined and included in a block.  The main reason for your ticket
-not being mined is that the ticket price adjusts before it can be mined.  This
-can happen due to the mempool being full of competing ticket purchase
-transactions or simply bad purchase timing.  You can use the official Decred stats site at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org) to view when the next ticket price adjustment occurs.
-
-Some other details to keep in mind are:
-
-* The ticket price is not spent, although it is removed from your balance as it is not spendable. It is just a deposit. You will get it back when your ticket votes, expires, or is revoked due to not voting.
-* 20 tickets are accepted into the voting pool each block. Tickets that are waiting stay in the mempool. Tickets are moved from the mempool to the voting pool in order of txfee.
-* Tickets take 256 blocks (about a day) to mature. During this time the stake price you paid will not be visible in your total balance.
-* You can keep track of your tickets' status by periodically running:
-
-```no-highlight
-dcrctl --wallet getstakeinfo
-```
-
-  or by inspecting the Stake Mining tab in Paymetheus.
-
-Continue to [PoS Tickets and Fees FAQ](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
----
-
-## ** <i class="fa fa-book"></i> See Also **
-
-[Proof-of-stake Commands](/advanced/program-options.md#pos-commands)
-
-[Proof-of-stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
-[Proof-of-stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
-
-[Proof-of-stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
-
-[Proof-of-stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
-
-[Proof-of-stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)
+[Proof-of-Stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)

--- a/docs/mining/proof-of-stake.md
+++ b/docs/mining/proof-of-stake.md
@@ -1,6 +1,6 @@
 # **Proof-of-Stake (PoS) Mining**
 
-Last updated v0.8.2 - April 11, 2017
+Last updated for v0.8.2
 
 This document is meant to be an educational resource for Proof-of-Stake mining (staking) with Decred. It will cover the purpose of the Proof-of-Stake protocol, a brief introduction to the staking process, a ticket lifecycle, and get you started with ticket buying. 
 

--- a/es_docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/es_docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,0 +1,208 @@
+# **Buying Tickets With dcrwallet**
+
+Last updated for v0.8.2 on 4/18/2017
+
+This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
+
+**Prerequisites:**
+
+- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
+- [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
+- Familiarize yourself with the [basics of using dcrctl](/getting-started/user-guides/dcrctl-basics.md).
+- Familiarize yourself with the [staking process](/mining/proof-of-stake.md#staking-101) and the [ticket lifecycle](/mining/proof-of-stake.md#ticket-lifecycle)
+
+This guide assumes you have set up `dcrd` and `dcrwallet` using configuration files. If you used `dcrinstall`, you have configuration files already. Using configuration files is highly recommended - it makes for an easier time issuing commands to `dcrwallet` and `dcrd` through `dcrctl`. A guide for minimum configuration (saving your RPC username and RPC password) can be found [here](/getting-started/startup-basics.md#minimum-configuration). 
+
+NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]` and `[Ticket Buyer Options]`. Any setting prefixed by 'tickeybuyer.' must be placed within the lower `[Ticket Buyer Options]` section. All other settings go within `[Application Options]`. 
+
+---
+
+## **Decisions**
+
+There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
+
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+
+Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+
+Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
+
+---
+
+## **Solo-voting**
+
+REMINDER: Solo-voting with a voting wallet that doesn't stay online 24/7 may result in missed votes and forfeited stake rewards.
+
+To solo-vote, you simply set the enablevoting option when starting `dcrwallet`, unlock the wallet with your private passphrase, and buy tickets. With enablevoting enabled and `dcrwallet` unlocked, your wallet will automatically handle voting.
+
+To set up your `dcrwallet` for solo-staking, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enablevoting=1
+
+Once restarted with that line in `dcrwallet.conf` your wallet will be configured for solo-voting and you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Stakepool-voting**
+
+To allow a stakepool to vote for you, you first have to sign up for a stakepool. A list of them can be found [here](/mining/proof-of-stake.md#list-of-stakepools). After signing up, there should be directions for creating a new P2SH address and importing your multi-sig voting script. A brief overview is provided here:
+
+1. With your wallet open, issue the `dcrctl --wallet getnewaddress` command to retrieve an address.
+2. Using that address, issue the `dcrctl --wallet validateaddress <address from step 1>` command. This should return a JSON object that will be displayed like so:
+```
+{
+  "isvalid": true,
+  "address": "DsExampleAddr1For2Demo3PurposesOnly",
+  "ismine": true,
+  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
+  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
+  "iscompressed": true,
+  "account": "voting"
+}
+```
+3. Copy the `pubkeyaddr` into the stakepool's "Submit Address" form and hit the submit button. The page should redirect you to the tickets page, which will display more instructions.
+4. At the top of the tickets page, you should see a "Ticket Information" section. Copy your "Redeem Script" and use it to issue the `dcrctl --wallet importscript <Insert Redeem Script Here>` command.
+
+With the stakepool configured and your multi-sig script imported to your wallet, you can now start [purchasing tickets](#ticket-purchasing).
+
+---
+
+## **Ticket Purchasing**
+
+Both manual and automatic ticket purchasing require your wallet to be unlocked via the `dcrcrl --wallet walletpassphrase <private passphrase> <time limit>` command.
+
+There are three things you might want to understand before purchasing tickets: the `purchaseticket` command, when/why a `ticketfee` is important, and the significance of `ticket price`.
+
+> purchaseticket Command
+
+The `purchaseticket` command will be used to purchase tickets whether manual or automatic. Let's take a closer look at the command and its arguments:
+
+```
+purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
+```
+
+1. `fromaccount`    =  Required String: The account from which to purchase tickets (e.g. "default").
+2. `spendlimit`     =  Required Number: Limit on the amount to spend on ticket (e.g. 50).
+3. `minconf`        =  Optional Number: Minimum number of block confirmations required (e.g. 1).
+4. `ticketaddress`  =  Optional String: The ticket address to which voting rights are given
+5. `numtickets`     =  Optional Number: The number of tickets to purchase at once (e.g. 1)
+6. `pooladdress`    =  Optional String: The address to pay stake pool fees to
+7. `poolfees`       =  Optional Number: The percentage of fees to pay to the stake pool (e.g. 5)
+8. `expiry`         =  Optional Number: The block height where unmined tickets will expire from the mempool, returning the original DCR to your "fromaccount". If left blank, tickets will only expire in the mempool when the ticket price changes.
+9. `comment`        =  Optional String: This argument is unused and has no significance. 
+
+> Ticket Fees
+
+Your `ticketfee` is the DCR/kB rate you'll pay to have your ticket purchase be included in a block by a miner. You'll notice that the above ticketpurchase command doesn't include any `ticketfee` arguments. The `ticketfee` argument can be set two ways.
+
+1. During startup by adding `ticketfee=<fee rate>` to the `[Application Options]` of your `dcrwallet.conf`.
+2. While your wallet is running, using the `dcrctl --wallet setticketfee <fee rate>` command. This is not a permanent setting and will default to 0.01 every time your wallet is restarted unless a ticketfee is specified in `dcrwallet.conf`.
+
+Why are ticketfees important? Usually the default fee of 0.01 is enough to get your tickets mined. The exception is during a fee war event. When the ticket price falls very low, demand outpaces supply (there are only a maximum of 2880 tickets available at each price interval). This creates a fee war, with stakeholders competing to get their tickets mined before the price changes.
+
+With these two things in mind, let's continue to the two methods for purchasing tickets.
+
+> Ticket Price
+
+To get the current ticket price, issue the `dcrctl --wallet getstakeinfo` command and look for the `difficulty` value. This is the price of each ticket in the current price window. You'll want to adjust your `spendlimit` argument in the `purchaseticket` command to be greater than this `difficulty` value when purchasing tickets manually.
+
+--- 
+
+#### **Manual Ticket Purchase**
+
+Before manually purchasing tickets, it is recommended to check for a ticketfee war and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command. Third party sites such as https://dcrstats.com and https://posmaster.info can be used to find the average ticketfee in the mempool, although you may oftentimes be able to purchase a ticket with a ticketfee lower than the average.
+
+> Solo Tickets
+
+To purchase tickets used for solo-staking, you only need to specify the `fromaccount` and `spendlimit` arguments while using the `purchaseticket` command. For example: `dcrctl --wallet purchaseticket "default" 50` would use DCR from your `default` account to purchase a ticket if the current ticket price was a max of 50 DCR.
+
+If you wish to specify the `numticket` or `expiry` arguments, you would specify a `minconf` of 1, an empty `ticketaddress` (""), an empty `pooladdress` (""), and an empty `poolfees` (0). Two example follow:
+
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5` would purchase 5 tickets, as the 5th argument (`numtickets`) is set to 5.
+* `dcrctl --wallet purchaseticket "default" 50 1 "" 5 "" 0 100000` would purchase 5 tickets that would expire from the mempool if not mined by block 100,000, as the 8th argument (`expiry`) is set to 100000.
+ 
+Be sure to check for a fee war event and adjust your ticketfee before purchase by issuing the `dcrctl --wallet setticketfee <fee rate>` command.
+
+> Pool Tickets
+
+To purchase tickets with their voting rights delegated to a stakepool, we have to use the full `purchaseticket` command.
+
+* Your `ticketaddress` is the P2SH Address found at the top of "Tickets" page of your Stakepool under the "Ticket Information" section.
+* Your `pooladdress` is the address for your Stakepool's fees are collected. This can be found in the "Ticket Instructions" section of your Stakepool's "Tickets" page.
+* Your `poolfees` is the percentage of the stake reward that will go to the `pooladdress` when a ticket votes. It is important to match your pool's advertised fee. 
+
+A quick example: 
+
+`dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5` would use DCR from your `default` account to purchase 1 ticket if the current ticket price is a max of 23 DCR. The P2SH Address received from the stakepool is `DcExampleAddr1For2Demo3PurposesOnly` and their fee address is `DsExampleAddr1For2Demo3PurposesOnly`. They will collect a 7.5% fee if this ticket successfully votes. This ticket will not expire from the mempool until the ticket price changes, as only 7 arguments were specified (no `expiry`).
+
+---
+
+#### **Ticketbuyer Configuration**
+
+To set up your `dcrwallet` to enable its built-in ticketbuyer feature, add the following line to your `dcrwallet.conf` config file in the `[Application Options]` section:
+
+    enableticketbuyer=1
+
+If you are using a Stakepool, you should also add the following lines (all of these can be found on your Stakepool's "Tickets" page):
+
+    ticketaddress=<P2SH Address shared with Stakepool>
+    pooladdress=<Stakepool's Fee Collection Address>
+    poolfees=<Stakepool's Required Reward Fee>
+
+You might also want to configure `ticketbuyer`.
+
+`ticketbuyer` will use the following default settings (also found in the chart [below](#full-ticketbuyer-options)) unless they are otherwise specified in your `dcrwallet.conf` file in the `[Ticket Buyer Options]` section:
+
+* **ticketbuyer.avgpricemode=vwap** - ticketbuyer uses a volume weighted average price formula to calculate the average ticket price.
+* **ticketbuyer.avgpricevwapdelta=2880** - ticketbuyer uses the last 2880 tickets in the vwap calculation.
+* **ticketbuyer.maxfee=0.1** - ticketbuyer will never buy a ticket with a fee rate higher than 0.1.
+* **ticketbuyer.minfee=0.01** - ticketbuyer will never buy a ticket with a fee rate lower than 0.01.
+* **ticketbuyer.feesource=median** - ticketbuyer uses a median to calculate fee rate, in which half of fees are higher and half of fees are lower.
+* **ticketbuyer.maxperblock=5** - ticketbuyer will by a maximum of 5 tickets per block if fee and price are within range.
+* **ticketbuyer.blockstoavg=10** - the number of blocks used to calculate the average fee rate.
+* **ticketbuyer.feetargetscaling=1** - ticketbuyer multiplies the average fee by 1 to calculate the fee rate to attempt to use.
+* **ticketbuyer.maxinmempool=40** - ticketbuyer will never allow your mempool tickets to exceed 40.
+* **ticketbuyer.expirydelta=16** - tickets that aren't mined within 16 blocks are refunded to you.
+* **ticketbuyer.maxpricerelative=1.25** - ticketbuyer will never buy a ticket with a ticker price higher than (average price * 1.25).
+* **ticketbuyer.balancetomaintainrelative=0.3** - ticketbuyer will not use more than 70% of your funds to purchase tickets.
+
+A full list of `ticketbuyer` options can be found [below](#full-ticketbuyer-options). There are many variables that can be customized to get `ticketbuyer` to behave exactly how you want. 
+
+With `ticketbuyer` running and your wallet unlocked, you can watch your `dcrwallet` console to see whether or not tickets are being purchased. It will even display an explanation if tickets weren't purchased.
+
+---
+
+## **Full Ticketbuyer Options**
+
+We recommended you read
+and understand the options available before using the feature as you may set your fees and ticket 
+prices higher than desired.
+
+All of these options can be specified on the command line or in dcrwallet.conf. Note that at
+this time there is no way to change settings while dcrwallet is running: you will need to restart it to 
+adjust your settings.
+
+Parameter|Description|Default|Explanation
+:----------:|:---------------------------:|:----------:|:---------------------------:
+ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
+ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
+ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
+ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
+ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
+ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
+ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
+ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
+ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
+ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
+ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
+ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
+ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
+ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
+ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
+ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
+ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+
+---

--- a/es_docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/es_docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -1,12 +1,12 @@
 # **Buying Tickets With dcrwallet**
 
-Last updated for v0.8.2 on 4/18/2017
+Last updated for v0.8.2
 
 This guide is intended to walk through ticket buying using `dcrwallet`. It will cover both manual ticket purchase and automatic ticket purchase for solo-voting and stakepool-voting configurations.
 
 **Prerequisites:**
 
-- Use either the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrctl`. Additional steps will be required if another installation method was used.
+- Use the latest [dcrinstall](/getting-started/install-guide.md#dcrinstall) to install `dcrd`, `dcrwallet,` and `dcrctl`. Additional steps will be required if another installation method was used.
 - Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 - [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
@@ -23,9 +23,9 @@ NOTE: `dcrwallet.conf` is split into two sections labeled `[Application Options]
 
 There are a few decisions to be made before venturing into this guide. First, will you be using a stakepool to delegate your ticket voting rights? Second, will you be purchasing tickets manually or automatically via the ticketbuyer feature?
 
-Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online 24/7 and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
+Stakepool ticket purchasing allows a stakeholder to delegate voting rights to a stakepool. These stakepools are online at all times (24/7) and very rarely miss a vote. They utilize multi-sig transactions so they're unable to touch any of your DCR. As a downside, most require a small percentage of your voting reward as a pool fee. Stakepool delegated tickets also require a larger transaction size (~540 Bytes vs. ~300 Bytes for solo-voting tickets) for purchasing which results in a slightly higher absolute ticket fee since fees are calculated by DCR/kB.
 
-Solo-voting requires you to have a voting wallet unlocked at all times, or else you can miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
+Solo-voting requires you to have a voting wallet unlocked at all times (24/7), or else you may miss votes and lose your voting reward. You do not have to pay pool fees and your ticket purchases are more likely to be mined with a smaller absolute fee (due to the miners selecting tickets based on DCR/kB ticket fee rates and solo tickets having a smaller TXN size).
 
 Manual ticket purchasing vs. automated ticketbuyer purchasing is mainly up to personal preference. The normal benefits of automation apply to ticketbuyer, but many may be overwhelmed by the amount variables that can be configured. Also, ticketbuyer's fee calculation sometimes doesn't result in the most economical fee for a stakeholder. Some people also enjoy manually purchasing tickets every few days and trying to bid the most economical fee. Both methods will only purchase tickets when your wallet is unlocked.
 

--- a/es_docs/mining/proof-of-stake.md
+++ b/es_docs/mining/proof-of-stake.md
@@ -1,49 +1,88 @@
-# ** Proof-of-Stake (PoS) Mining**
+# **Proof-of-Stake (PoS) Mining**
+
+Last updated for v0.8.2
+
+This document is meant to be an educational resource for Proof-of-Stake mining (staking) with Decred. It will cover the purpose of the Proof-of-Stake protocol, a brief introduction to the staking process, a ticket lifecycle, and get you started with ticket buying. 
 
 ---
 
-## ** Overview **
+## **Overview**
 
-This document explains the process by which one purchases a ticket with DCR by
-sending an SStx transaction.  If the transaction is successfully mined, it will
-then go through a 256 block maturation period.  Once mature, the ticket will be
-randomly selected to vote on PoW blocks as covered by the
-[general mining overview](/mining/proof-of-stake.md).
+Decred's unique Proof-of-Stake protocol serves multiple purposes:
 
----
+To provide a metric for stakeholders/end-user support of any consensus updates. That is, stakeholders are able to vote on specific proposals/agenda on the Decred blockchain. Agendas may include deciding whether or not the dev team spends time implementing a specific feature, activating the code of a feature already submitted for implementation, or making other decisions such as how the dev subsidy should be spent.
 
-## ** Prerequisites **
-
-- A running [dcrd](/getting-started/user-guides/dcrd-setup.md) Instance
-- A running [dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) Instance
-- [dcrctl basics](/getting-started/user-guides/dcrctl-basics.md) such as unlocking your wallet.
-- [Obtain some DCR](/getting-started/obtaining-dcr.md)
+Decred's PoS also provides a system of checks and balances for nonconforming miners. Stakeholders can vote a block invalid if it doesn't match to the consensus rules of the network. 
 
 ---
 
-## ** Solo Mining or Pool Mining **
+## **Staking 101**
 
-> <i class="fa fa-male"></i> Solo Mining
+To participate in proof-of-stake mining, stakeholders lock some DCR in return for a ticket. Every ticket owned gives a stakeholder the ability to cast a single vote. Upon voting, each ticket returns a small reward plus the original **Ticket Price** of the ticket. Each ticket is selected to vote at random, giving an average vote time of 28 days, but possibly requiring up to 142 days, with a .5% chance of expiring before being chosen to vote (this expiration returns the original **Ticket Price** without a reward). Every block mined must include 5 votes (Miners are penalized by a reward deduction if less than 5 votes are included). Every block mined can also include up to 20 fresh ticket purchases. A new ticket requires 256 block to mature before it is entered into the **Ticket Pool* and able to be called upon to vote.
 
-<i class="fa fa-exclamation-triangle"></i> **In order to successfully
-take part in PoS, you need to make sure that your wallet is online 24/7. This
-is because your ticket may be called on to vote at any time and if your wallet
-is unable to respond you will lose the vote reward.  The amount of your ticket
-purchase will be returned minus transaction fees.**
+There are a few important variables that you should familiarize yourself with while staking.
 
-> <i class="fa fa-users"></i> Pool Mining
+Every 144 blocks (~12 hours), the stake difficulty algorithm calculates a new **Ticket Price** in an attempt to keep the **Ticket Pool** size near the target pool size of 40,960 tickets. This 144 block window is referred to as the `StakeDiffWindowSize`.
 
-Using a stake pool is beneficial because the servers are geographically
-distributed and redundant which vastly increases the odds that your vote
-will always be cast even if a network or server outage occurs.
-The stake pools charge a fee to pay for server costs and system
-administration labor.
+The **Ticket Price**/**Stake Difficulty** is the price you must pay for a ticket during a single 144 block window.
+
+The **Ticket Pool** is the total number of tickets in the Decred network.
+
+The **Ticket Fee** (`ticketfee`) is the fee rate that must be included in the ticket purchase to incentivize Proof-of-Work miners to include that ticket in a new block. **Ticket Fee** usually refers to the DCR/kB fee rate for a ticket purchase transaction. Therefore, with a higher transaction size, you will end up paying a higher absolute fee. For example, solo-staking ticket purchases are around 300kB, which means a **Ticket Fee** of .3 DCR/kB will result in the spending on .1 DCR if, and only if, that ticket gets included in a block.
+
+When the **Ticket Price** gets relatively low for a single **Ticket Window**, you can usually expect a fee market to form, with many stakeholders trying to buy tickets before the window ends. When the **Ticket Price** is not at an extremely low and profitable price, the default **Ticket Fee** of 0.01 DCR/kB rate is usually high enough to be included in a block. Keep in mind that 
+
+When a ticket is called to vote, the wallet that has voting rights for that ticket must be online. If the wallet is not online to cast its vote, the ticket will be marked as `missed` and you will not receive a reward for that ticket. Stakepools are offered as a solution for those that cannot have a voting wallet online 24/7.
+
+Stakepools allow stakeholders to generate ticket purchase transactions that give a stakepool voting rights for your ticket. They vote on your behalf, usually requiring a small fee for participation (under 7%) which covers the cost of hosting the minimum of 3 servers required to run a stakepool. This fee is known as the **Pool Fee** and is only taken out of the small PoS reward. A list of stakepools can be found [below](#list-of-stakepools).
 
 ---
 
-## **<i class="fa fa-life-ring"></i> Sign Up For a Stake Pool**
+## **Ticket Lifecycle**
 
-These stake pools are officially recognized:
+Purchasing a ticket for PoS is quite simple (see below) but what happens to it after you buy it?
+A ticket on main net (test net uses different parameters) will go through a few stages in its lifetime:
+
+1. You buy a ticket using a Paymetheus <!--, Decrediton,--> or dcrwallet wallet. The total cost of the each single ticket transaction should be **Ticket Price** + **Ticket Fee**(`ticketfee`).
+2. Your ticket enters the `mempool`. This is where your ticket waits to be mined by PoW miners. Only 20 fresh tickets are mined into each block.
+3. Tickets are mined into a block in with higher **Ticket Fee** transactions having a higher priority. Note that the **Ticket Fee** is DCR per KB of the transaction. A few common transaction sizes are 298kB (a solo ticket purchase) and 539kB (a pool ticket purchase).
+4. **A -** If your ticket is mined into a block, it becomes an immature ticket. This state lasts for 256 blocks (about 20 hours). During this time the ticket cannot vote. At this point, the ticket fee is non-refundable. <br /> 
+**B -** If your ticket is not mined, both the **Ticket Price** and **Ticket Fee** are returned to the purchasing account.
+5. After your ticket matures (256 blocks), it enters the **Ticket Pool** and is eligible for voting.
+6. The chance of a ticket voting is based on a Poisson distribution with a mean of 28 days. After 28 days a ticket has a 50% chance to have already voted.
+7. Given a target pool size of 40960 tickets, any given ticket has a 99.5% chance of voting within ~142 days (about 4.7 months). If, after this time, a ticket has not voted, it expires. You receive a refund on the original **Ticket Price**.
+8. A ticket may miss its call to vote if the voting wallet does not respond or two valid blocks are found within close proximity of each other. If this happens, you receive a refund on the original **Ticket Price**.
+9. After a ticket has voted, missed, or expired, the funds (ticket price and subsidy if applicable, minus the fee) will enter immature status for another 256 blocks, after which they are released. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet which then frees up the locked ticket outputs. **NOTE:** Revocations can only be submitted for a corresponding missed ticket. You cannot revoke a ticket until it is missed.
+
+---
+
+## **How to Stake**
+
+A wallet that is open and unlocked 24/7 is *highly recommended* for staking. Any loss in uptime may result in a loss of vote and reward. Stakepools are available for those unable to keep a personal voting wallet online forever.
+
+The only other requirement for staking is that you buy a ticket. Below you can find guides for buying tickets using [Paymetheus](#paymetheus) and [dcrwallet](#dcrwallet).
+
+If you intend to use a stakepool, you must first sign up for one. Links to officially recognized stakepools are provided [here](#list-of-stakepools).
+
+---
+
+## **Paymetheus**
+
+The Paymetheus application is unable to vote itself, which means that voting rights must be assigned to a stakepool.
+
+Please see the [Purchase Tickets tab guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab) for Paymetheus to learn how to buy tickets using Paymetheus and a stakepool.
+
+---
+
+## **dcrwallet**
+
+The [Buying Tickets with dcrwallet](/getting-started/user-guides/dcrwallet-tickets.md) guide will show you how to buy tickets manually and automatically for pool or solo staking.
+
+---
+
+## **<i class="fa fa-life-ring"></i> List of Stakepools**
+
+These stakepools are officially recognized:
 
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakepool.net](https://dcr.stakepool.net)
 * [<i class="fa fa-external-link-square"></i> https://dcr.stakeminer.com](https://dcr.stakeminer.com)
@@ -56,228 +95,24 @@ These stake pools are officially recognized:
 
 You can find a comparison of each pool's fees and statistics by visiting the
 [<i class="fa fa-external-link-square"></i> Decred website](https://decred.org)
-and clicking the 'Stakepools' link within the footer.
-
-Each pool runs the same software which will walk you through the ticket buying
-process. The instructions are also below so you may view them without signing
-up for a pool.
+and clicking the 'Stakepools' link within the footer at the bottom of the page.
 
 ---
 
-## **<i class="fa fa-ticket"></i> Automatic Purchasing Of Tickets**
+<!-- TODO: **Purchasing Tickets with Decrediton** -->
 
-You can set up dcrwallet to automatically purchase tickets on your behalf. We recommended you read
-and understand the options available before using the feature as you may set your fees and ticket 
-prices higher than desired.
+## **Additional Information**
 
-All of these options can be specified on the command line or in dcrwallet.conf. Note that at
-this time there is no way to change settings while dcrwallet is running. You will need to restart it to 
-adjust your settings.
+[Proof-of-Stake Commands](/advanced/program-options.md#pos-commands)
 
-Parameter|Description|Default|Explanation
-:----------:|:---------------------------:|:----------:|:---------------------------:
-ticketbuyer.maxpricescale|Attempt to prevent the stake difficulty from going above this multiplier (>1.0) by manipulation, 0 to disable|2|If purchasing tickets at this price window would cause the next window to be higher than ```(price * multiplier)```, do not buy tickets. This may cause you not buy tickets when otherwise you could. Recommend to set to 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.pricetarget|A target to try to seek setting the stake price to rather than meeting the average price, 0 to disable |0 DCR|Attempt to buy tickets in order to force the future price to '''pricetarget'''. Leave this at 0. This option has been deprecated and will be removed in a future version.
-ticketbuyer.avgpricemode|The mode to use for calculating the average price if pricetarget is disabled (vwap, pool, dual) |vwap|!
-ticketbuyer.avgpricevwapdelta|The number of blocks to use from the current block to calculate the VWAP |2880|!
-ticketbuyer.maxfee|Maximum ticket fee per KB |0.1 DCR|Tickets are entered into the mempool in order of their fee per kilobyte. This sets the maximum fee you are willing to pay.
-ticketbuyer.minfee|Minimum ticket fee per KB |0.01 DCR|The minimum fee per kilobyte you are willing to pay. This should probably be left at 0.01 unless you know what you're doing.
-ticketbuyer.feesource|The fee source to use for ticket fee per KB (median or mean) |median|The fee chosen by the ticket buyer will be based off either the median (line all the fees up in order and choose the middle one) or the mean (also known as the average; add all the fees up and divide by 2). It's recommended to leave this at median as there have been instances of fee manipulation where people try to force up the average by buying one ticket with a very high fee.
-ticketbuyer.maxperblock|Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks |5|Do not buy more than this number of tickets per block. A negative number means buy one ticket every n blocks. e.g. -2 would mean buy a ticket every second block.
-ticketbuyer.blockstoavg|Number of blocks to average for fees calculation |11| Fees are calculated using this many previous blocks. You can usually leave this at the default.
-ticketbuyer.feetargetscaling|Scaling factor for setting the ticket fee, multiplies by the average fee |1|The average fee is multipled by this number to give the fee to pay. DO NOT change this until you really know what you're doing. It could raise your fees very high. Remember, fees are non-refundable!
-ticketbuyer.dontwaitfortickets|Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more| |By default, the ticket buyer will not buy more tickets until all the previous ones purchased have been entered into the blockchain. You can set this to purchase more even if some are still in the mempool.
-ticketbuyer.spreadticketpurchases|Spread ticket purchases evenly throughout the window| |By default all tickets are purchased at once. This setting allows tells the ticket buyer to spread out the purchase of tickets which may result in more favourable fees.
-ticketbuyer.maxinmempool|The maximum number of your tickets allowed in mempool before purchasing more tickets |40|If you have this many tickets in the mempool, the ticket buyer will not buy more until some are accepted into the blockchain.
-ticketbuyer.expirydelta|Number of blocks in the future before the ticket expires |16|You can set an expiry so that if your tickets are not accepted into the blockchain due to high fees, they will cancel and you can try again by raising your fees.
-ticketbuyer.maxpriceabsolute|Maximum absolute price to purchase a ticket |0 DCR| If the ticket price is above this value, you will not buy more tickets. The default of 0 turns this off.
-ticketbuyer.maxpricerelative|Scaling factor for setting the maximum price, multiplies by the average price |1.25|If the current window price is significantly higher than the last few windows, do not buy any tickets. E.g. With the default value of 1.25, if the average price of the last few windows is 50DCR, you won't buy any tickets if the current window is over 75DCR.
-ticketbuyer.balancetomaintainabsolute|Amount of funds to keep in wallet when stake mining |0 DCR| If you balance is lower than this number, you will not buy tickets. The default of 0 will use all the funds in your account to buy tickets.
-ticketbuyer.balancetomaintainrelative|Proportion of funds to leave in wallet when stake mining |0.3|Similar to the last one, except it's based on a percentage of your total funds.
+[Proof-of-Stake FAQ - General](/faq/proof-of-stake/general.md)
 
----
+[Proof-of-Stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
 
-## **<i class="fa fa-ticket"></i> Manual Purchasing Of Tickets**
+[Proof-of-Stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
 
-> Obtaining Ticket Price and Block Height
+[Proof-of-Stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
 
-First, get the current ticket price from the **difficulty** field from **getstakeinfo**:
+[Proof-of-Stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
 
-```no-highlight
-dcrctl --wallet getstakeinfo
-{
-  "poolsize": 42670,
-  "difficulty": 22.07045882,
-  "allmempooltix": 0,
-  "ownmempooltix": 0,
-  "immature": 0,
-  "live": 0,
-  "proportionlive": 0,
-  "voted": 0,
-  "totalsubsidy": 0,
-  "missed": 0,
-  "proportionmissed": 0,
-  "revoked": 0
-}
-```
-
-It is also helpful to get the **height** field from **getbestblock** so you may
-use the ticket expiration functionality:
-
-```no-highlight
-dcrctl --wallet getblockheight
-{
-  "hash": "0000000000000d14cab9056131a0461778a7f8cd1066cb343307882bd730f2a9",
-  "height": 35472
-}
-```
-
-Getting this information directly is the most reliable and accurate but you may
-also use the official stats page at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org).
-
-> Purchaseticket Syntax
-
-Now purchase your ticket(s) via dcrctl.  The full syntax for the command is:
-
-```no-highlight
-dcrctl --wallet help purchaseticket
-purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment")
-
-Purchase ticket using available funds.
-
-Arguments:
-1. fromaccount   (string, required)             The account to use for purchase (default="default")
-2. spendlimit    (numeric, required)            Limit on the amount to spend on ticket
-3. minconf       (numeric, optional, default=1) Minimum number of block confirmations required
-4. ticketaddress (string, optional)             Override the ticket address to which voting rights are given
-5. numtickets    (numeric, optional)            The number of tickets to purchase
-6. pooladdress   (string, optional)             The address to pay stake pool fees to
-7. poolfees      (numeric, optional)            The amount of fees to pay to the stake pool
-8. expiry        (numeric, optional)            Height at which the purchase tickets expire
-9. comment       (string, optional)             Unused
-
-Result:
-"value" (string) Hash of the resulting ticket
-```
-
-> Manual Ticket Purchasing Example (Solo)
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 "" 1 "" 0.0 35482
-```
-
-This purchases one ticket from the default account for a maximum of 23 DCR that
-expires at block 35482.
-
-The command will return a ticket hash / transaction id if successful.
-
-> dcrwallet Manual Ticket Purchasing Example (Pool)
-
-The ticket purchasing part for a pool is much the same but there are some more
-steps involved to allow both you and the pool to vote by creating a
-multisignature script and P2SH address.
-
-Once you sign up for a stake pool, you will be redirected to an address
-submission page.
-
-To join the pool, provide a public key address which can be used to generate a
-1-of-2 multisignature script. The multisignature script will be generated by
-the pool and returned to you along with a P2SH address to give voting rights to.
-The P2SH address starts with **Dc** on mainnet.
-
-It is recommended to generate a new account when joining a stake pool.  This is
-because accounts are hardened so in the case of a total stake pool
-failure/shutdown, it would be safe to give the private key to another stake pool
-as long as that account only does voting and nothing else.
-
-```no-highlight
-dcrctl --wallet createnewaccount voting
-```
-
-To generate a public key address, create a new wallet address with **getnewaddress &lt;account&gt;**.
-Then, call **validateaddress &lt;yourAddress&gt;** and retrieve the address listed in the
-**pubkeyaddr** field of the response. It is prefixed with **Dk** on mainnet.
-
-The following is an example for mainnet:
-
-```no-highlight
-dcrctl --wallet getnewaddress voting
-DsExampleAddr1For2Demo3PurposesOnly
-dcrctl --wallet validateaddress DsExampleAddr1For2Demo3PurposesOnly
-{
-  "isvalid": true,
-  "address": "DsExampleAddr1For2Demo3PurposesOnly",
-  "ismine": true,
-  "pubkeyaddr": "DkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
-  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
-  "iscompressed": true,
-  "account": "voting"
-}
-```
-
-Copy and paste the **pubkeyaddr** into the stake pool's submit address form
-and click the submit button.  Your multisig script and P2SH address will be
-generated and you will be redirected to the tickets page.
-
-Now simply follow the directions on the tickets page. First, import the
-multisig script locally into your wallet using dcrctl for safe keeping,
-so you can recover your funds and vote in the unlikely event of a pool
-failure:
-
-```no-highlight
-dcrctl --wallet importscript <ReallyLongScriptDisplayedOnPoolPage>
-```
-
-Now **purchaseticket** with the stake pool-specific fields set:
-
-```no-highlight
-dcrctl --wallet purchaseticket "default" 23 1 DcExampleAddr1For2Demo3PurposesOnly 1 DsExampleAddr1For2Demo3PurposesOnly 7.5 35482
-```
-
-This purchases one ticket which is delegated to the P2SH address from the default
-account for a maximum of 23 DCR that expires at block 35482 and pays a 7.5% fee
-to the pool's payment address.
-
-> Paymetheus Manual Ticket Purchasing Example (Pool)
-
-Please see the [Using Paymetheus guide](/getting-started/user-guides/using-paymetheus.md#purchase-tickets-tab)
----
-
-## ** Post Purchase Information **
-
-After a successful ticket purchase, you must wait to see whether or not the
-transaction is mined and included in a block.  The main reason for your ticket
-not being mined is that the ticket price adjusts before it can be mined.  This
-can happen due to the mempool being full of competing ticket purchase
-transactions or simply bad purchase timing.  You can use the official Decred stats site at [<i class="fa fa-external-link-square"></i> stats.decred.org](https://stats.decred.org) to view when the next ticket price adjustment occurs.
-
-Some other details to keep in mind are:
-
-* The ticket price is not spent, although it is removed from your balance as it is not spendable. It is just a deposit. You will get it back when your ticket votes, expires, or is revoked due to not voting.
-* 20 tickets are accepted into the voting pool each block. Tickets that are waiting stay in the mempool. Tickets are moved from the mempool to the voting pool in order of txfee.
-* Tickets take 256 blocks (about a day) to mature. During this time the stake price you paid will not be visible in your total balance.
-* You can keep track of your tickets' status by periodically running:
-
-```no-highlight
-dcrctl --wallet getstakeinfo
-```
-
-  or by inspecting the Stake Mining tab in Paymetheus.
-
-Continue to [PoS Tickets and Fees FAQ](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
----
-
-## ** <i class="fa fa-book"></i> See Also **
-
-[Proof-of-stake Commands](/advanced/program-options.md#pos-commands)
-
-[Proof-of-stake FAQ - Buying Tickets and Fees](/faq/proof-of-stake/buying-tickets-and-fees.md)
-
-[Proof-of-stake FAQ - Solo Mining](/faq/proof-of-stake/solo-mining.md)
-
-[Proof-of-stake FAQ - Stake Pools](/faq/proof-of-stake/stake-pools.md)
-
-[Proof-of-stake FAQ - Voting Tickets](/faq/proof-of-stake/voting-tickets.md)
-
-[Proof-of-stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)
+[Proof-of-Stake Mining Parameters](/advanced/program-options.md#pos-network-parameters)

--- a/es_mkdocs.yml
+++ b/es_mkdocs.yml
@@ -28,6 +28,7 @@ pages:
     - 'dcrd Setup': 'getting-started/user-guides/dcrd-setup.md'
     - 'dcrwallet Setup': 'getting-started/user-guides/dcrwallet-setup.md'
     - 'dcrctl Basics': 'getting-started/user-guides/dcrctl-basics.md'
+    - 'Buying Tickets': 'getting-started/user-guides/dcrwallet-tickets.md'
   - 'Web Wallet': 'getting-started/user-guides/web.md'
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ pages:
     - 'dcrd Setup': 'getting-started/user-guides/dcrd-setup.md'
     - 'dcrwallet Setup': 'getting-started/user-guides/dcrwallet-setup.md'
     - 'dcrctl Basics': 'getting-started/user-guides/dcrctl-basics.md'
+    - 'Buying Tickets': 'getting-started/user-guides/dcrwallet-tickets.md'
   - 'Web Wallet': 'getting-started/user-guides/web.md'
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'


### PR DESCRIPTION
This included an overhaul to the proof-of-stake.md to provide more higher level information about the staking protocol. This page now will link to specific guides for ticket purchase with each appliaction.

Closes #155