### PR TITLE
macOS Inconsistency

### DIFF
--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -2,9 +2,9 @@
 
 ---
 
-The newest Binary Releases can be found here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). With the exception of the `.msi` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be unzip and go, instructions are provided for Mac, Linux, and Windows below (assumed proficiency for *BSD users).
+The newest Binary Releases can be found here: [https://github.com/decred/decred-binaries/releases](https://github.com/decred/decred-binaries/releases). With the exception of the `.msi` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be unzip and go, instructions are provided for macOS, Linux, and Windows below (assumed proficiency for *BSD users).
 
-> OSX/macOS
+> macOS
 
 1. Download the correct file:
 


### PR DESCRIPTION
Changed **Mac** and **OS X** to **macOS**, since Apple's operating system name has changed. [https://www.apple.com/macos/sierra/](https://www.apple.com/macos/sierra/)