### PR TITLE
macOS Inconsistency #1

### DIFF
--- a/docs/getting-started/cli-differences.md
+++ b/docs/getting-started/cli-differences.md
@@ -4,7 +4,7 @@ This page was last updated for v1.0.0.
 
 ---
 
-The purpose of this page is to explain the key differences for running the cross-platform command-line applications on Windows, Linux, and macOS/OSX.
+The purpose of this page is to explain the key differences for running the cross-platform command-line applications on Windows, Linux, and macOS.
 
 ---
 


### PR DESCRIPTION
Changed **macOS/OSX** to **macOS**, since Apple's operating system name has changed. [https://www.apple.com/macos/sierra/](https://www.apple.com/macos/sierra/)