### PR TITLE
macOS Inconsistency #3

### DIFF
--- a/docs/getting-started/user-guides/cli-installation.md
+++ b/docs/getting-started/user-guides/cli-installation.md
@@ -8,11 +8,11 @@ This page was last updated for v1.0.1.
 
 `dcrinstall` is the recommended method to install the Decred command line interface tools `dcrd`, `dcrwallet`, and `dcrctl`.
 
-`dcrinstall` is an automatic installer and upgrader for the Decred software. The newest release can be found here: [https://github.com/decred/decred-release/releases/tag/v1.0.8](https://github.com/decred/decred-release/releases/tag/v1.0.8). Binaries are provided for Windows, OSX/macOS, Linux, OpenBSD, and FreeBSD. Executing installer will install `dcrd`, `dcrwallet`, and `dcrctl`. Instructions are provided for Mac, Linux, and Windows below (assumed proficiency for *BSD users).
+`dcrinstall` is an automatic installer and upgrader for the Decred software. The newest release can be found here: [https://github.com/decred/decred-release/releases/tag/v1.0.8](https://github.com/decred/decred-release/releases/tag/v1.0.8). Binaries are provided for Windows, macOS, Linux, OpenBSD, and FreeBSD. Executing installer will install `dcrd`, `dcrwallet`, and `dcrctl`. Instructions are provided for macOS, Linux, and Windows below (assumed proficiency for *BSD users).
 
 `dcrinstall` will automatically download the precompiled, signed binary package found on GitHub, verify the signature of this package, copy the binaries within the package to a specific folder dependent on OS, create configuration files with settings to allow the 3 applications to communicate with each other, and run you through the wallet creation process. After running through `dcrinstall`, you will be able to launch the software with no additional configuration.
 
-> OSX/macOS:
+> macOS:
 
 1. Download the correct file:
 


### PR DESCRIPTION
Changed **OSX/macOS** and **Mac** to **macOS**, since Apple's operating system name has changed. [https://www.apple.com/macos/sierra/](https://www.apple.com/macos/sierra/)