### PR TITLE
macOS Inconsistency #5

### DIFF
--- a/docs/advanced/verifying-binaries.md
+++ b/docs/advanced/verifying-binaries.md
@@ -17,7 +17,7 @@ Project, there are a couple pieces of software required:
 * GnuPG or PGP -- This is required to import public keys and verify
   signatures. Examples below use GnuPG.
 
-The following instructions should work as is on Linux/UNIX/OSX.
+The following instructions should work as is on Linux/UNIX/macOS.
 Windows users will have to install sha256 and gnupg themselves and use
 the windows cmd terminal to do this.  The steps to verify the binaries
 are as follows:

--- a/docs/getting-started/user-guides/dcrctl-basics.md
+++ b/docs/getting-started/user-guides/dcrctl-basics.md
@@ -7,7 +7,7 @@ This guide is intended to help you learn the basic commands of the `dcrctl` appl
 **Prerequisites:**
 
 - Use the latest [dcrinstall](/getting-started/user-guides/cli-installation.md) to install `dcrctl`. Additional steps will be required if another installation method was used.
-- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- Review how the launch commands for the Command Prompt (Windows) and Bash (macOS/Linux) shells differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 - [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
 

--- a/docs/getting-started/user-guides/dcrd-setup.md
+++ b/docs/getting-started/user-guides/dcrd-setup.md
@@ -7,7 +7,7 @@ This guide is intended to help you setup the `dcrd` application using [startup f
 **Prerequisites:**
 
 - Use the latest [dcrinstall](/getting-started/user-guides/cli-installation.md) to install `dcrd`. Additional steps will be required if another installation method was used.
-- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- Review how the launch commands for the Command Prompt (Windows) and Bash (macOS/Linux) shells differ [here](/getting-started/cli-differences.md).
 
 ---
 

--- a/docs/getting-started/user-guides/dcrwallet-setup.md
+++ b/docs/getting-started/user-guides/dcrwallet-setup.md
@@ -7,7 +7,7 @@ This guide is intended to help you setup the `dcrwallet` application using [star
 **Prerequisites:**
 
 - Use the latest [dcrinstall](/getting-started/user-guides/cli-installation.md) to install `dcrwallet`. Additional steps will be required if another installation method was used.
-- Review how the launch commands differ for the Command Prompt (Windows) and Bash (OSX/Linux) shells, and how the home directories differ [here](/getting-started/cli-differences.md).
+- Review how the launch commands differ for the Command Prompt (Windows) and Bash (macOS/Linux) shells, and how the home directories differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 
 ---

--- a/docs/getting-started/user-guides/dcrwallet-tickets.md
+++ b/docs/getting-started/user-guides/dcrwallet-tickets.md
@@ -7,7 +7,7 @@ This guide is intended to walk through ticket buying using `dcrwallet`. It will 
 **Prerequisites:**
 
 - Use the latest [dcrinstall](/getting-started/user-guides/cli-installation.md) to install `dcrd`, `dcrwallet,` and `dcrctl`. Additional steps will be required if another installation method was used.
-- Review how the launch commands for the Command Prompt (Windows) and Bash (OSX/Linux) shells differ [here](/getting-started/cli-differences.md).
+- Review how the launch commands for the Command Prompt (Windows) and Bash (macOS/Linux) shells differ [here](/getting-started/cli-differences.md).
 - [Setup dcrd](/getting-started/user-guides/dcrd-setup.md) and have it running in the background.
 - [Setup dcrwallet](/getting-started/user-guides/dcrwallet-setup.md) and have it running in the background.
 - Familiarize yourself with the [basics of using dcrctl](/getting-started/user-guides/dcrctl-basics.md).

--- a/docs/getting-started/using-testnet.md
+++ b/docs/getting-started/using-testnet.md
@@ -34,7 +34,7 @@ For Linux,
 2. Issue the command `./decrediton --testnet`.
 3. Decrediton will launch and attempt to connect to testnet2.
 
-For macOS/OSX,
+For macOS,
 
 1. Open your terminal and issue the following command: `/Applications/decrediton.app/Contents/MacOS/decrediton --testnet`
 2. Decrediton will launch and attempt to connect to testnet2.


### PR DESCRIPTION
Changed **macOS/OSX**  to **macOS**, since Apple's operating system name has changed. [https://www.apple.com/macos/sierra/](https://www.apple.com/macos/sierra/)