### PR TITLE
Fix incorrect staking information

### DIFF
--- a/docs/mining/proof-of-stake.md
+++ b/docs/mining/proof-of-stake.md
@@ -12,7 +12,7 @@ Decred's unique Proof-of-Stake protocol serves multiple purposes:
 
 To provide a metric for stakeholders/end-user support of any consensus updates. That is, stakeholders are able to vote on specific proposals/agenda on the Decred blockchain. Agendas may include deciding whether or not the dev team spends time implementing a specific feature, activating the code of a feature already submitted for implementation, or making other decisions such as how the dev subsidy should be spent. More information on voting can be found in our [Mainnet Voting Guide](/getting-started/user-guides/agenda-voting.md).
 
-Decred's PoS also provides a system of checks and balances for nonconforming miners. Stakeholders can vote a block invalid if it doesn't match to the consensus rules of the network. 
+Decred's PoS also provides a system of checks and balances for nonconforming miners. Stakeholders can vote a block invalid even if it technically matches the consensus rules of the network.
 
 ---
 


### PR DESCRIPTION
This doc currently says skatevoters can

> vote a block invalid if it doesn't match to the consensus rules

But that's technically incorrect. If a block doesn't match the consensus rules, it can't be mined on top of (no stakeholder action needed). The power of stakeholding is being able to reject otherwise **valid** blocks for whatever reason.