### PR TITLE
Introduce `Contributing` section.

### DIFF
--- a/docs/advanced/contributing.md
+++ b/docs/advanced/contributing.md
@@ -1,8 +1,4 @@
-# Decred Pull Requests and Contributions 
-
----
-
-All code for Decred is kept on GitHub.  This document provides some basic info on how we handle code contributions and some basic info on how to contribute. It is based partially on a similar document from [btcsuite](https://github.com/btcsuite).
+# Source Code Contributions 
 
 ---
 
@@ -12,26 +8,6 @@ A good first step is to read the [Code Contribution Guidelines documentation](ht
 project.  That document is primarily focused on the Go codebase but it is still a good start.
 
 The following examples will be split into two sections, one for the Go projects (dcrd, dcrwallet, gominer, etc), and one for projects that do not use Go (decrediton, insight, dcrdocs, etc).  In all cases, be sure to check out the README.md in each project if you need help setting the particular project up.
-
----
-
-## General Model 
-
-With this process we are trying to make contributing simple while also  maintaining a high level of code quality and clean history.  Members of the Decred team must follow the same procedures as external contributors.
-
-Our model for hacking code in outline form is as follows.  If any of this does not make sense, don't worry, it will be explained in more detail in the next sections.
-
-1. Find an issue you want to work on.  If there are none describing your issue, open one with what you are going to do.
-1. Make code changes on a branch.
-1. Push these changes to your own forked GitHub repo.
-1. When your code is ready to be reviewed or when you just want input from other devs open a Pull Request (PR) on the main repo from the GitHub web page.
-1. Add a comment on the PR that says what issue you are fixing.  Put the text Closes # or Fixes # followed by the number of the issue on a single line.  This will allow GitHub to automatically link the PR to the issue and close the issue when the PR is closed.
-1. You can request a specific reviewer from the GitHub webpage or you can ask someone on irc/slack to review.
-1. ALL code must be reviewed and receive at least one approval before it can go in.  Only team members can give official approval, but comments from other users are encouraged.
-1. If there are changes requested, make those changes and commit them to your local branch.
-1. Push those changes to the same branch you have been hacking on.  They will show up in the PR that way and the reviewer can then compare to the previous version.
-1. Once your code is approved, it can be merged into master.  To keep history clean, we only allow non-fast-forward merges (that means we want a linear history).  Most PRs also must be squashed to a single commit (although if there is reason to have it as multiple commits that can be considered on a case by case basis).
-1. If your PR is a single commit (or can be squashed by GitHub automatically) and is caught up with master, the reviewer will merge your PR.  If your branch was too far behind, you may be asked to rebase your commit.  Once that is done and pushed, the reviewer will merge your commit.
 
 ---
 
@@ -78,51 +54,10 @@ $ cd dcrdocs
 $ git remote add <yourname> https://github.com/<yourname>/dcrdocs.git
 ```
 
-## Creating a new feature pull request 
-- Find or create an issue on the GitHub repo (the original, not your fork) for the feature you want to work on.
-- Checkout a new feature branch to house the changes you will be making:
-
-```bash
-$ git checkout -b <feature_branch>
-```
-- Make whatever changes are necessary for the feature and commit them
-- Push your feature branch to your fork:
-
-```bash
-$ git push <yourname> <feature_branch>
-```
-- With your browser, navigate to https://github.com/decred/dcrd
-- Create a pull request with the GitHub UI.  You can request a reviewer on the GitHub web page or you can ask someone on irc/slack.
-
-## Rebasing one of your existing pull requests 
-
-Sometimes you will be requested to rebase and squash the pull request to the latest master branch.
-
-- Make sure the master branch is up-to-date:
-
-```bash
-$ git checkout master
-$ git pull
-```
-- Checkout the existing feature branch and rebase it with the interactive flag:
-
-```bash
-$ git checkout <feature_branch>
-$ git rebase -i master
-```
-- Follow the directions presented to specify 's' meaning squash for the additional commits (the first commit must remain 'p' or 'pick').
-- Write a single commit message in the editor that you have set to cover all the commits included.
-- Save and close the editor and git should generate a single commit with the message you specified and all the commits you added.  You can check the commit with the command ```git show```.
-- Force push the branch to your fork:
-
-```bash
-$ git push -f <yourname> <feature_branch>
-```
+---
 
 ## Other Considerations 
 
 There are a few other things to consider when doing a pull request.  In the case of the Go code, there is significant test coverage already.  If you are adding code, you should add tests as well.  If you are fixing something, you need to make sure you do not break any existing tests.  For the Go code, there is a script ```goclean.sh``` in each repo to run the tests and the any static checkers we have.  NO code will be accepted without passing all the tests.  In the case of the node.js code (decrediton) all code must pass eslint.  You can check this with the command ```npm run lint```.
-
-Finally, each repo has a LICENSE.  Your new code must be under the same LICENSE as the existing code and assigned copyright to 'The Decred Developers'.  In most cases this is the very liberal ISC license but a few repos are different.  Check the repo to be sure.
 
 If you have any questions for contributing, feel free to ask on irc/slack or GitHub.  Decred team members (and probably community members too) will be happy to help.

--- a/docs/advanced/contributor-compensation.md
+++ b/docs/advanced/contributor-compensation.md
@@ -1,0 +1,30 @@
+# Contributor Compensation
+
+---
+
+## Request for Proposals (RFP)
+
+Decred was launched with a Request For Proposal system in order to provide compensation for contributors working on larger or more significant projects. A document (RFP) would be produced which described the requirements and scope of a project, along with a clearly defined set of milestones and a reward specified in DCR. The RFP would be posted publicly and community members would be given a period of time to submit their proposals. After review, a proposal would be selected and awarded the contract.
+
+The RFPs were stored on GitHub and they can still be viewed. The first, [RFP-001](https://github.com/decred/RFPs/blob/master/rfp-0001/rfp-0001.md), was looking for developers to overhaul the Paymetheus application. RFP progress and payments were made public via the Decred forum[^1].
+
+The RFP process worked well for certain types of tasks, however a need arose to have contributors engaged and compensated over the longer term and on a more flexible basis[^2]. In January 2017 the RFP system was changed to a contractor model and Decred began to hire it's first contractors.
+
+---
+
+## Contractors
+
+Decred currently has over 20 active contractors and they can be viewed on the decred.org [Contributors](https://decred.org/contributors) page. The active contractors are made up of both individuals and corporate contractors. Contractors contribute in a wide variety of ways including software development, design, marketing, community management and documentation.
+
+Contractors submit a monthly invoice to DHG (Decred Holding Group) and are paid in Decred according to an hourly rate.
+
+### Becoming a Contractor
+
+The contractor model and how to get involved are thoroughly documented in the [Decred blog post "Decred Recruiting"](https://blog.decred.org/2017/07/25/Decred-Recruiting/). If you are interested, please start by reading this blog post thoroughly - it should contain everything you need to know to get started. We look forward to your contributions!
+
+---
+
+## <i class="fa fa-book"></i> Sources 
+
+[^1]: Decred Forum, [RFP - Status And Expenditures](https://forum.decred.org/threads/status-and-expenditures.2864/)
+[^2]: Decred Blog, [2017 Decred Roadmap](https://blog.decred.org/2017/01/09/2017-Decred-Roadmap/)

--- a/docs/advanced/user-projects.md
+++ b/docs/advanced/user-projects.md
@@ -1,4 +1,4 @@
-# User Projects 
+# Contributor Projects
 
 ---
 

--- a/docs/advanced/using-github.md
+++ b/docs/advanced/using-github.md
@@ -1,0 +1,76 @@
+# Using GitHub
+
+---
+
+GitHub is the primary version control used for all Decred projects. This document provides some basic info on how we handle contributions and some basic info on how to contribute.
+
+---
+
+## General Model
+
+With this process we are trying to make contributing simple while also maintaining a high level of code quality and clean history. Members of the Decred team must follow the same procedures as external contributors.
+
+Our model for contributing in outline form is as follows. If any of this does not make sense, don't worry, it will be explained in more detail in the next sections.
+
+1. Find an issue you want to work on. If there are none describing your issue, open one with what you are going to do.
+1. Make changes on a branch.
+1. Push these changes to your own forked GitHub repo.
+1. When your changes are ready to be reviewed or when you just want input from other devs open a Pull Request (PR) on the main repo from the GitHub web page.
+1. Add a comment on the PR that says what issue you are fixing. Put the text Closes # or Fixes # followed by the number of the issue on a single line. This will allow GitHub to automatically link the PR to the issue and close the issue when the PR is closed.
+1. You can request a specific reviewer from the GitHub webpage or you can ask someone on IRC/Slack to review.
+1. ALL changes must be reviewed and receive at least one approval before they can go in. Only team members can give official approval, but comments from other users are encouraged.
+1. If there are changes requested, make those changes and commit them to your local branch.
+1. Push those changes to the same branch you have been working on. They will show up in the PR that way and the reviewer can then compare to the previous version.
+1. Once your changes are approved, they can be merged into master. To keep history clean, we only allow non-fast-forward merges (that means we want a linear history). Most PRs also must be squashed to a single commit (although if there is reason to have it as multiple commits that can be considered on a case by case basis).
+1. If your PR is a single commit (or can be squashed by GitHub automatically) and is caught up with master, the reviewer will merge your PR. If your branch was too far behind, you may be asked to rebase your commit. Once that is done and pushed, the reviewer will merge your commit.
+
+---
+
+## Creating a new feature pull request 
+- Find or create an issue on the GitHub repo (the original, not your fork) for the feature you want to work on.
+- Checkout a new feature branch to house the changes you will be making:
+
+```bash
+$ git checkout -b <feature_branch>
+```
+- Make whatever changes are necessary for the feature and commit them
+- Push your feature branch to your fork:
+
+```bash
+$ git push <yourname> <feature_branch>
+```
+- With your browser, navigate to https://github.com/decred/dcrd
+- Create a pull request with the GitHub UI. You can request a reviewer on the GitHub web page or you can ask someone on irc/slack.
+
+## Rebasing one of your existing pull requests 
+
+Sometimes you will be requested to rebase and squash the pull request to the latest master branch.
+
+- Make sure the master branch is up-to-date:
+
+```bash
+$ git checkout master
+$ git pull
+```
+- Checkout the existing feature branch and rebase it with the interactive flag:
+
+```bash
+$ git checkout <feature_branch>
+$ git rebase -i master
+```
+- Follow the directions presented to specify 's' meaning squash for the additional commits (the first commit must remain 'p' or 'pick').
+- Write a single commit message in the editor that you have set to cover all the commits included.
+- Save and close the editor and git should generate a single commit with the message you specified and all the commits you added. You can check the commit with the command ```git show```.
+- Force push the branch to your fork:
+
+```bash
+$ git push -f <yourname> <feature_branch>
+```
+
+---
+
+## Other Considerations 
+
+Each GitHub repo has a LICENSE. Your new code must be under the same LICENSE as the existing code and assigned copyright to 'The Decred Developers'. In most cases this is the very liberal ISC license but a few repos are different. Check the repo to be sure.
+
+If you have any questions for contributing, feel free to ask on irc/slack or GitHub. Decred team members (and probably community members too) will be happy to help.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,8 +90,6 @@ pages:
   - 'Deleting Your Wallet': 'advanced/deleting-your-wallet.md'
   - 'Advanced dcrctl Usage': 'advanced/dcrctl-usage.md'
   - 'Simnet': 'advanced/simnet.md'
-  - 'Contributing Guidelines': 'advanced/contributing.md'
-  - 'User Projects': 'advanced/user-projects.md'
 - Research:
   - 'Overview': 'research/overview.md'
   - 'Hybrid Design': 'research/hybrid-design.md'
@@ -103,6 +101,12 @@ pages:
   - 'Transaction Extensions': 'research/transaction-extensions.md'
   - 'Schnorr Signatures': 'research/schnorr-signatures.md'
   - 'Miscellaneous Improvements': 'research/miscellaneous-improvements.md'
+- Contributing:
+  - 'Contributor Compensation': 'advanced/contributor-compensation.md'
+  - 'Contributor Projects': 'advanced/user-projects.md'
+  - Guidelines:
+    - 'Using GitHub': 'advanced/using-github.md'
+    - 'Source Code Contributions': 'advanced/contributing.md'
 - About:
   - 'Support Directory': 'support-directory.md'
   - 'Credits': 'about/credits.md'


### PR DESCRIPTION
- Move `User Projects` and `Contribution Guidelines` into a new `Contributing` section
- Rename `User Projects` to `Contributor Projects`
- Split `Contribution Guidelines` into `Using GitHub` and `Source Code Contributions` - some contributors are new to GitHub and don't necessarily need the extra overhead of golang/javascript specifics.
- New `Contributor Compensation` page which describes the old RFP process and the new contractor process. Links into the blog post for full details.
