### PR TITLE
Update theme override paths for fonts & icons

### DIFF
--- a/theme_override/base.html
+++ b/theme_override/base.html
@@ -62,7 +62,7 @@
             }}">
         <style>body,input{font-family:"{{ font.text }}","Helvetica Neue",Helvetica,Arial,sans-serif}code,kbd,pre{font-family:"{{ font.code }}","Courier New",Courier,monospace}</style>
       {% endif %}
-      <link rel="stylesheet" href="assets/fonts/material-icons.css">
+      <link rel="stylesheet" href="{{ base_url }}/assets/fonts/material-icons.css">
     {% endblock %}
     {% for path in extra_css %}
       <link rel="stylesheet" href="{{ path }}">

--- a/theme_override/partials/social.html
+++ b/theme_override/partials/social.html
@@ -1,6 +1,6 @@
 {% if config.extra.social %}
   <div class="md-footer-social">
-    {% set path = "assets/fonts/font-awesome.min.css" %}
+    {% set path = "/assets/fonts/font-awesome.min.css" %}
     <link rel="stylesheet" href="{{ path }}">
     {% for social in config.extra.social %}
       <a href="{{ social.link }}" class="md-footer-social__link fa fa-{{ social.type }}"></a>


### PR DESCRIPTION
- Absolute path for Font Awesome style
- Include base url in path for Material Icons style

This should help with pages such as:

https://docs.decred.org/getting-started/using-the-block-explorer/

which currently 404 on the Font Awesome and Material CSS in the live documentation site.