### PR TITLE
Added note to click revoke ticket for missed tickets when using GUI

### DIFF
--- a/docs/faq/proof-of-stake/voting-tickets.md
+++ b/docs/faq/proof-of-stake/voting-tickets.md
@@ -36,7 +36,9 @@ For a more concrete example, assume the current chain tip is at block 5,000. The
 
 #### 6. What happens if a ticket I have missed a vote? 
 
-When using dcrwallet, your wallet will automatically revoke the ticket in the block after it is missed[^13912], so you get them back just after they were missed as immature funds (that means they will not be spendable for 256 blocks when they mature). If you stake tickets with the GUI wallet Decrediton, you will need to click "Revoke Ticket" after the ticket is missed.
+If using dcrwallet with the enablevoting option set, tickets will automatically be revoked once missed[^13912]. The funds from the revoked ticket will be returned as immature and will not be mature (spendable) for 256 blocks.
+
+If you are using the GUI wallet Decrediton, you will need to click the "Revoke Ticket" button if a ticket is missed.
 
 For example:
 

--- a/docs/faq/proof-of-stake/voting-tickets.md
+++ b/docs/faq/proof-of-stake/voting-tickets.md
@@ -36,7 +36,7 @@ For a more concrete example, assume the current chain tip is at block 5,000. The
 
 #### 6. What happens if a ticket I have missed a vote? 
 
-Your wallet will automatically revoke the ticket in the block after it is missed[^13912], so you get them back just after they were missed as immature funds (that means they will not be spendable for 256 blocks when they mature).
+When using dcrwallet, your wallet will automatically revoke the ticket in the block after it is missed[^13912], so you get them back just after they were missed as immature funds (that means they will not be spendable for 256 blocks when they mature). If you stake tickets with the GUI wallet Decrediton, you will need to click "Revoke Ticket" after the ticket is missed.
 
 For example:
 

--- a/docs/faq/proof-of-stake/voting-tickets.md
+++ b/docs/faq/proof-of-stake/voting-tickets.md
@@ -36,7 +36,7 @@ For a more concrete example, assume the current chain tip is at block 5,000. The
 
 #### 6. What happens if a ticket I have missed a vote? 
 
-If using dcrwallet with the enablevoting option set, tickets will automatically be revoked once missed[^13912]. The funds from the revoked ticket will be returned as immature and will not be mature (spendable) for 256 blocks.
+If using dcrwallet with the --enablevoting option set, tickets will automatically be revoked once missed[^13912]. The funds from the revoked ticket will be returned as immature and will not be mature (spendable) for 256 blocks.
 
 If you are using the GUI wallet Decrediton, you will need to click the "Revoke Ticket" button if a ticket is missed.
 


### PR DESCRIPTION
This PR is meant to address #382. Clarification is added to specify that missed tickets are not automatically revoked when staked via Decrediton and adds instruction on how to revoke.