### PR TITLE
Removes paras explaining what cryptocurrency and blockchain are, twea…

### DIFF
--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -4,7 +4,7 @@
 
 ## Welcome To Decred 
 
-This guide offers signposts to some useful resources, including how to set up your Decred wallet, buy DRC, participate in Decred’s governance, connect with the community and contribute to the project (contributors welcome!). 
+This guide offers signposts to some useful resources, including how to set up your Decred wallet, buy DCR, participate in Decred’s governance, connect with the community and contribute to the project (contributors welcome!). 
 
 ## Wallets
 

--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -4,23 +4,13 @@
 
 ## Welcome To Decred 
 
-This beginner's guide introduces Decred and offers signposts to some useful resources.
-
-Decred is an autonomous digital currency. Stakeholders make and enforce the blockchain's consensus rules, set a course for future development, and decide how the project's treasury is used to fund it. Decred's blockchain is similar to Bitcoin's, but with major aspects of [governance](../governance/governance.md) baked into the protocol. 
-
-[Proof of Work](../mining/proof-of-work.md) miners play a similar role for Decred as they do for Bitcoin, but with Decred they only receive 60% of the block reward.
-
-[Proof of Stake](../mining/proof-of-stake.md) voting is central to Decred's governance. Decred holders can time-lock (or "stake") DCR to obtain voting tickets. Tickets are randomly called to vote on-chain, this involves both approving the work of PoW miners and voting Yes/No on any open [rule change proposals](user-guides/agenda-voting.md). 30% of the block reward goes to the holders of the tickets that voted in that block.
-
-The remaining 10% of the block reward goes into a [Project Treasury fund](https://explorer.dcrdata.org/address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx). Holders of live tickets decide how that treasury is used through [Politeia proposals and voting](../governance/politeia.md).
-
-The [Decred Constitution](constitution.md) sets out some guiding principles for the project, the constitution is subject to amendment through Politeia proposals.
+This guide offers signposts to some useful resources, including how to set up your Decred wallet, buy DRC, participate in Decred’s governance, connect with the community and contribute to the project (contributors welcome!). 
 
 ## Wallets
 
-[Decrediton](user-guides/decrediton-setup.md) is Decred's GUI wallet, it supports Voting through [stakepools](https://decred.org/stakepools/) and offers the easiest way to start buying tickets and participating in governance.
+[Decrediton](user-guides/decrediton-setup.md) is Decred's GUI wallet. It supports Voting through [stakepools](https://decred.org/stakepools/) and offers the easiest way to start buying tickets and participating in governance.
 
-There is also a [Command Line Interface](user-guides/cli-installation.md) and set of tools for more advanced users, these include running a personal Voting wallet.
+There is also a [Command Line Interface](user-guides/cli-installation.md) that exposes more advanced functionality, including the ability to run a personal Voting wallet.
 
 ## General Guides 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,16 +7,18 @@ Decred is a blockchain-based cryptocurrency with a strong focus on community inp
 
 ---
 
-## <img class="dcr-icon" alt="cryptocurrency" src="/img/dcr-icons/Cryptocurrency.svg" /> What is a cryptocurrency?
-A cryptocurrency is a system of 'value exchange', just like any real world currency you may be familiar with. Its main difference is that it is not controlled by a central government or group and thus cannot be manipulated or restricted in the way those currencies can be.
+## How Does it Work?
+Stakeholders make and enforce the blockchain's consensus rules, set a course for future development, and decide how the project's treasury is used to fund it. Decred's blockchain is similar to Bitcoin's, but with major aspects of [governance](governance/governance.md) baked into the protocol. 
 
-As an example, you may buy Decred from a fiat currency exchange and use it to directly purchase a product in a different country without having to pay high exchange rates.
-Decred uses a wallet to store, transfer and receive DCR. This wallet signs every transaction in and out with a special private key that is unique to you. This is how the network knows that the address sending the transaction is the correct one. Think of your bank account and PIN. When you use your card (wallet), you also enter your PIN (private key), so the bank knows it was you that authorized the transaction. When you first start using Decred, your wallet will generate a private key that you must not give to anyone.
+To align incentives, block rewards are split between PoW miners, stakeholders and the Project Treasury, which funds Decred’s development. 
 
----
+[Proof of Work](mining/proof-of-work.md) miners play a similar role for Decred as they do for Bitcoin, but with Decred they only receive 60% of the block reward.
 
-## <img class="dcr-icon" alt="blocks" src="/img/dcr-icons/Blocks.svg" /> What is the blockchain?
-The blockchain is the heart of Decred. It is where all transactions that take place are stored. It is similar to a bank ledger in that it records all the activity that happens when DCR are transferred. This ledger is able to confirm that new transactions are valid and that no fraud is taking place.
+[Proof of Stake](mining/proof-of-stake.md) voting is central to Decred's governance. Decred holders can time-lock (or "stake") DCR to obtain voting tickets. Tickets are randomly called to vote on-chain; this involves both approving the work of PoW miners and voting Yes/No on any open [rule change proposals](getting-started/user-guides/agenda-voting.md). 30% of the block reward goes to the holders of the tickets that voted in that block.
 
-Each block in the blockchain is a record of transactions that have occurred since the last block (about 5 minutes). Every computer (node) in the Decred network shares this blockchain. Nodes in the network run an algorithm many times over a block looking for a solution with a known difficulty. This process is known as "proof-of-work" mining. Once the solution is found it is broadcast to the network. The network then verifies the solution (finding the solution is very hard, but verifying it is easy). Decred uses an extra step of verification known as "proof-of-stake" mining. Stakeholders who have purchased tickets now have the chance to vote on the block. 5 tickets are chosen randomly from the ticket pool and if at least 3 of them vote 'yes' the block is permanently added to the blockchain and the transactions are cleared. Both PoS and PoW miners are compensated with DCR for the resources used to mine the block.
+The remaining 10% of the block reward goes into a [Project Treasury fund](https://explorer.dcrdata.org/address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx). Holders of live tickets decide how that treasury is used through [Politeia proposals and voting](governance/politeia.md).
+
+The [Decred Constitution](getting-started/constitution.md) sets out some guiding principles for the project; the constitution is subject to amendment through Politeia proposals.
+
+
 


### PR DESCRIPTION
Removes paragraphs explaining what cryptocurrency and blockchain are from the Home page, tweaks wording on Home and Beginner's Guide pages (closes #626 ).

Per mentioned in the issue, I think we should remove the 'What is cryptocurrency?' and 'What is blockchain?' paragraphs from the Home page. I've replaced these deleted paragraphs with introductory text from the Beginner's Guide page, as I think this is a better place for that content. On the Beginner's Guide page, I've made a few small tweaks (a couple minor grammar fixes, rewording for flow, a couple new sentences), but mainly just moving existing content around. 