### PR TITLE
Add version numbers as template variables

### DIFF
--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -16,8 +16,8 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         | Architecture | Filename                          |
         | ------------ | ----------------------------------|
-        | 32-bit       | `decred-windows-386-v1.2.0.zip`   |
-        | 64-bit       | `decred-windows-amd64-v1.2.0.zip` |
+        | 32-bit       | `decred-windows-386-v{{ cliversion.windows }}.zip`   |
+        | 64-bit       | `decred-windows-amd64-v{{ cliversion.windows }}.zip` |
 
     1. Navigate to download location and extract the `.zip` file:
 
@@ -29,14 +29,14 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         | Architecture | Filename                            |
         | ------------ | ----------------------------------- |
-        | 64-bit       | `decred-darwin-amd64-v1.2.0.tar.gz` |
+        | 64-bit       | `decred-darwin-amd64-v{{ cliversion.mac }}.tar.gz` |
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
         **Finder:** simply double click on the `.tar.gz` file.
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v1.2.0.tar.gz` should extract to `decred-darwin-amd64-v1.2.0`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion.mac }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion.mac }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
 
     !!! note
 
@@ -48,10 +48,10 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         | Architecture | Filename                           |
         | ------------ | ---------------------------------- |
-        | 32-bit       | `decred-linux-386-v1.2.0.tar.gz`   |
-        | 64-bit       | `decred-linux-amd64-v1.2.0.tar.gz` |
-        | 32-bit ARM   | `decred-linux-arm-v1.2.0.tar.gz`   |
-        | 64-bit ARM   | `decred-linux-arm64-v1.2.0.tar.gz` |
+        | 32-bit       | `decred-linux-386-v{{ cliversion.linux }}.tar.gz`   |
+        | 64-bit       | `decred-linux-amd64-v{{ cliversion.linux }}.tar.gz` |
+        | 32-bit ARM   | `decred-linux-arm-v{{ cliversion.linux }}.tar.gz`   |
+        | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion.linux }}.tar.gz` |
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
@@ -59,7 +59,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v1.2.0.tar.gz` should extract to `decred-linux-amd64-v1.2.0`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion.linux }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion.linux }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
 
 ---
 

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -16,19 +16,19 @@ Last updated for CLI release v1.1.2.
 
     1. Download the correct file:
 
-        For 32-bit computers, download the `dcrinstall-darwin-386-v1.1.2` file.
+        For 32-bit computers, download the `dcrinstall-darwin-386-v{{ cliversion.mac }}` file.
 
-        For 64-bit computers, download the `dcrinstall-darwin-amd64-v1.1.2` file.
+        For 64-bit computers, download the `dcrinstall-darwin-amd64-v{{ cliversion.mac }}` file.
 
-    1. Make dcrinstall-darwin-xxxx-vx.x.x an executable within your terminal, and run it:
+    1. Make dcrinstall-darwin-xxxx-v{{ cliversion.mac }} an executable within your terminal, and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
 
         `cd ~/Downloads/`
 
-        `chmod u+x dcrinstall-darwin-amd64-v1.1.2`
+        `chmod u+x dcrinstall-darwin-amd64-v{{ cliversion.mac }}`
 
-        `./dcrinstall-darwin-amd64-v1.1.2`
+        `./dcrinstall-darwin-amd64-v{{ cliversion.mac }}`
 
     1. The executable binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
@@ -36,23 +36,23 @@ Last updated for CLI release v1.1.2.
 
     1. Download the correct file:
 
-        For 32-bit computers, download the `dcrinstall-linux-386-v1.1.2` file.
+        For 32-bit computers, download the `dcrinstall-linux-386-v{{ cliversion.linux }}` file.
 
-        For 64-bit computers, download the `dcrinstall-linux-amd64-v1.1.2` file.
+        For 64-bit computers, download the `dcrinstall-linux-amd64-v{{ cliversion.linux }}` file.
 
-        For 32-bit ARM computers, download the `dcrinstall-linux-arm-v1.1.2` file.
+        For 32-bit ARM computers, download the `dcrinstall-linux-arm-v{{ cliversion.linux }}` file.
 
-        For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v1.1.2` file.
+        For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion.linux }}` file.
 
-    1. Make dcrinstall-linux-xxxx-vx.x.x an executable within your terminal, and run it:
+    1. Make dcrinstall-linux-xxxx-v{{ cliversion.linux }} an executable within your terminal, and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run chmod with u+x mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
 
         `cd ~/Downloads/`
 
-        `chmod u+x dcrinstall-linux-amd64-v1.1.2`
+        `chmod u+x dcrinstall-linux-amd64-v{{ cliversion.linux }}`
 
-        `./dcrinstall-linux-amd64-v1.1.2`
+        `./dcrinstall-linux-amd64-v{{ cliversion.linux }}`
 
     1. The binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
@@ -60,9 +60,9 @@ Last updated for CLI release v1.1.2.
 
     1. Download the correct file:
 
-        For 32-bit computers, download the `dcrinstall-windows-386-v1.1.2.exe` file.
+        For 32-bit computers, download the `dcrinstall-windows-386-v{{ cliversion.windows }}.exe` file.
 
-        For 64-bit computers, download the `dcrinstall-windows-amd64-v1.1.2.exe` file.
+        For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion.windows }}.exe` file.
 
     1. Run the dcrinstall executable file.
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -18,7 +18,7 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
 ??? info "Windows instructions (click to expand)"
 
-    1. Download the Windows installer `decrediton-v1.3.1.exe`.
+    1. Download the Windows installer `decrediton-v{{ decreditonversion.windows }}.exe`.
 
     1. Double click the installer and follow the instructions.
 
@@ -26,17 +26,17 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
 ??? info "macOS instructions (click to expand)"
 
-    1. Download the `decrediton-v1.3.1.dmg` file.
+    1. Download the `decrediton-v{{ decreditonversion.mac }}.dmg` file.
 
-    1. Double click the `decrediton-v1.3.1.dmg` file to mount the disk image.
+    1. Double click the `decrediton-v{{ decreditonversion.mac }}.dmg` file to mount the disk image.
 
     1. Drag the `decrediton.app` file into the link to your Applications folder within the disk image.
 
 ??? info "Linux instructions (click to expand)"
 
-    1. Download the `decrediton-v1.3.1.tar.gz` file.
+    1. Download the `decrediton-v{{ decreditonversion.mac }}.tar.gz` file.
 
-    1. Navigate to the download location and extract `decrediton-v1.3.1.tar.gz`.
+    1. Navigate to the download location and extract `decrediton-v{{ decreditonversion.mac }}.tar.gz`.
 
     1. The extracted files include an executable named `decrediton`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,14 @@ theme:
   logo: 'img/decred_logo_symbol_128.svg'
   font: false
 extra:
+  decreditonversion:
+    windows: 1.4.0-rc3
+    linux: 1.4.0-rc3
+    mac: 1.4.0-rc3
+  cliversion:
+    windows: 1.4.0-rc3
+    linux: 1.4.0-rc3
+    mac: 1.4.0-rc3
   social:
     - type: 'github'
       link: 'https://github.com/decred'
@@ -37,6 +45,8 @@ extra_javascript:
 extra_css:
   - css/fonts.css
   - css/style.css
+plugins:
+  - markdownextradata
 nav:
 - 'Home': 'index.md'
 - Getting Started:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.0.4
 mkdocs-material==3.3.0
+mkdocs-markdownextradata-plugin==0.0.5
 fontawesome-markdown==0.2.6


### PR DESCRIPTION
Closes #584 
Introduces a new mkdocs plugin to parse md markup and add template variable functionality
https://github.com/rosscdh/mkdocs-markdownextradata-plugin

Edit the `mkdocs.yml` and add `extra:` variables:

```yaml
extra:
  decreditonversion:
    windows: 1.3.1
    linux: 1.3.1
    mac: 1.3.1
  cliversion:
    windows: 1.3.0
    linux: 1.3.0
    mac: 1.3.0
```
`extra:` variables were only available in the html themes, but the plugin enables the use further down in the markup files.
In the `*.md` files use the template variables by using:
```jinja
{{ decreditonversion.windows }}
{{ cliversion.linux }}
```
