### PR TITLE
Adds politeiavoter CLI option to Pi page

### DIFF
--- a/docs/governance/politeia.md
+++ b/docs/governance/politeia.md
@@ -16,7 +16,7 @@ There is a fee for submitting a proposal (0.1 DCR), to limit the potential for p
 
 Reddit-style **up/down voting** is used for **proposal and comment sorting only**. Up/down votes are not anonymous.
 
-Ticket-voting on proposals doesn’t happen directly on Politeia, but from within a Decred wallet.
+Ticket-voting on proposals doesn’t happen directly on Politeia, but within [Decrediton](https://docs.decred.org/getting-started/user-guides/decrediton-setup/) or [politeiavoter CLI](https://github.com/decred/politeia/tree/master/politeiavoter) with dcrwallet
 
 **Censorship**  
 


### PR DESCRIPTION
Adds politeiavoter CLI tool as option for voting ( Closes #664 ). This tool is stable and in use. The README documentation on the linked repo is solid (confirmed by ay-p on Slack). 