### PR TITLE
Updates PoW page with up-to-date info on block rewards, GPU mining

### DIFF
--- a/docs/mining/proof-of-work.md
+++ b/docs/mining/proof-of-work.md
@@ -7,8 +7,12 @@
 Proof-of-work mining, more commonly referred to as PoW mining, is the activity
 of committing your computer’s hardware and resources to process network
 transactions and build the blocks that make up the blockchain in the Decred
-network. Each time a block is created (by a miner), about 30 new Decred coins
-are made. These coins are then split up as follows:
+network. Each time a block is created (by a miner), which is then approved by 
+ticket holders, new coins are created. These new coins are called the block reward. 
+The block reward adjusts every 6,144 blocks (approximately 21.33 days) by reducing
+by a factor of 100/1011. 
+
+Each new block reward is then split up as follows:
 
 Subsidy | Party
 ---     | ---
@@ -16,12 +20,18 @@ Subsidy | Party
 30%   | PoS Voters
 10%   | Decred development subsidy
 
+
+For more details on the growth of the coin supply, see the 
+[inflation](../advanced/inflation.md) page. 
+
 You will, on average, receive a reward that is roughly proportional to the
 hashrate of your miner and the overall hashrate of the network when you commit
-your computer to PoW mining. To get started, you must have a computer with a
-video card. Most video cards can be used for mining (including the "mobile"
-types found in some laptops). In general, higher end video cards perform at
-higher hashrates and therefore receive higher rewards.
+your computer to PoW mining. 
+
+PoW mined can be done using GPUs. However, ASICs that mine DCR are now available, 
+and since their inception the PoW difficulty has become high enough to make GPU 
+mining unlikely to be profitable. 
+
 ---
 
 ## Solo Mining or Pool Mining  

--- a/docs/mining/proof-of-work.md
+++ b/docs/mining/proof-of-work.md
@@ -8,9 +8,10 @@ Proof-of-work mining, more commonly referred to as PoW mining, is the activity
 of committing your computer’s hardware and resources to process network
 transactions and build the blocks that make up the blockchain in the Decred
 network. Each time a block is created (by a miner), which is then approved by 
-ticket holders, new coins are created. These new coins are called the block reward. 
+ticket holders, the miner receives a block reward (newly created DCR). If the
+block is rejected by ticket holders, the miner does not receive a reward. 
 The block reward adjusts every 6,144 blocks (approximately 21.33 days) by reducing
-by a factor of 100/1011. 
+by a factor of 100/101. 
 
 Each new block reward is then split up as follows:
 
@@ -24,12 +25,12 @@ Subsidy | Party
 For more details on the growth of the coin supply, see the 
 [inflation](../advanced/inflation.md) page. 
 
-You will, on average, receive a reward that is roughly proportional to the
+Miners typically receive a reward that is roughly proportional to the
 hashrate of your miner and the overall hashrate of the network when you commit
 your computer to PoW mining. 
 
-PoW mined can be done using GPUs. However, ASICs that mine DCR are now available, 
-and since their inception the PoW difficulty has become high enough to make GPU 
+PoW mining can be done using GPUs. However, ASICs that mine DCR are now available, 
+and since their introduction the PoW difficulty has become high enough to make GPU 
 mining unlikely to be profitable. 
 
 ---


### PR DESCRIPTION
Removes out-of-date numbers on block reward. Removes advice to mine on video card, adding note that ASICs are out now, making GPU mining unlikely to be profitable. ( Closes #674 ).