### PR TITLE
Removes bad link web wallet

### DIFF
--- a/docs/wallets/web.md
+++ b/docs/wallets/web.md
@@ -80,7 +80,7 @@ Option                                | Description
 Click `Backup`. You will see this screen:
 
 First of all, read the note. Only use ONE wallet at a time with a
-given seed (See: [FAQ](#)). You can have multiple wallets installed on
+given seed. You can have multiple wallets installed on
 different machines, but only one of them should be running at any
 given time. Click `Show Wallet Seed`. Write this down somewhere safe,
 or put it in an encrypted document to which you will not forget the


### PR DESCRIPTION
Removes a link, `(See: FAQ)`, which was just linking to the page it was on (inception link) ( Closes #688 ). Couldn't find a relevant page to link to - neither of the two FAQs that deal with wallets actually reference what the link points to. Also, some want to remove the web wallet documentation entirely (opening separate Issue for that). 