### PR TITLE
Cleans up formatting, tweaks wording

### DIFF
--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -12,9 +12,9 @@ Below is a screenshot of the root directory of the [decred-proposals/mainnet](ht
 
 ![The root of the mainnet repository. * = proposal folders, A = anchoring data](/img/politeia/mainnet-pi-repo.png)
 
-Folders marked with `*` contain proposal data. Folders and files marked with `A` contain anchoring data. Anchoring data relates to the anchoring of Politeia data to the Decred blockchain through dcrtime, which facilitates Politeia's transparent censorship functionality. This guide will not describe those files in detail, as they are not likely to be of interest for analysis. 
+Folders marked with `*` contain proposal data. Folders and files marked with `A` contain anchoring data. Anchoring data relates to the anchoring of Politeia data to the Decred blockchain through [dcrtime](https://github.com/decred/dcrtime), which facilitates Politeia's transparent censorship functionality. This guide will not describe those files in detail, as they are not likely to be of interest for analysis. 
 
-Within each proposal folder there are sequentially numbered sub-folders, one for each version of the proposal. The first folder ('/1') corresponds to the initial version of the proposal submitted to Politeia. If a proposal author updates their proposal (typically in response to community feedback), and resubmits it, that proposal and associated data is put into folder ('/2'), and so on. 
+Within each proposal folder there are sequentially numbered sub-folders, one for each version of the proposal. The first folder ('/1') corresponds to the initial version of the proposal submitted to Politeia. If a proposal author updates their proposal (typically in response to community feedback), the updated version and it's associated data are put into folder ('/2'), and so on.
 
 Below shows the contents of our example proposal's folder. As we can see, there are two versions of the proposal. 
 
@@ -26,25 +26,29 @@ If we click on the latest version ('/2'), we can see all the relevant data for t
 
 Below is a table with descriptions of the files and folders found in each proposal version folder. 
 
+#### Proposal data
+
 | Folder/File         | Description                   |  
 | -------------------- | ---------------------- |
-| **/payload**           | Folder containing an `index.md file`, which has the full text of the proposal and any images associated with the proposal.    |  
-| **/plugins/decred**         |  Folder containing the `comments.journal` file (which contains comments and up/down vote data) and, for proposals that have opened for voting, a `ballot.journal` file, which contains ticket voting data.   |  
+| **/payload**           | Folder containing an `index.md` file, which has the full text of the proposal and any images associated with the proposal.    |  
+| **/plugins/decred**         |  Folder containing the `comments.journal` file, which contains comments and up/down vote data for comments. If a proposal has begun voting (or finished voting), this folder will also contain a `ballot.journal` file containing the ticket holder voting data.    
 | **00.metadata.txt**          | Data about the proposal submission:   <ul style="font-size: 13px"><li>timestamp</li><li>pubkey of submitter</li><li>title</li> <li>signature</li></ul> |  
 | **02.metadata.txt**           | Data about admin approval for display: <ul style="font-size: 13px"><li>timestamp</li><li>pubkey of admin</li></ul>     |  
 | **13.metadata.txt:**           | Data about proposal owner authorizing the start of voting. Where proposal owner has authorized and then rescinded authorization this will appear in multiple commits:  <ul style="font-size: 13px"><li>timestamp</li><li>owner pubkey </li><li>transaction hash</li></ul>   |  
-| **14.metadata.txt**          | Data about admin authorizing the start of voting. Includes specification of the vote: duration (2016 blocks):   <ul style="font-size: 13px"><li>quorum requirement (20%)</li><li>approval threshold (60%)</li><li>id and descriptions for voting options</li></ul> |  
+| **14.metadata.txt**          | Data about admin authorizing the start of voting. Includes specification of the vote: duration (2016 blocks):   <ul style="font-size: 13px"><li>quorum requirement (20%) (subject to change)</li><li>approval threshold (60%) (subject to change)</li><li>id and descriptions for voting options</li></ul> |  
 | **15.metadata.txt**          | Data about voting period:  <ul style="font-size: 13px"><li>starting block height and hash</li><li>ending block height </li><li>a list of every ticket eligible to vote on the proposal</li></ul>    |  
 | **recordmetadata.json**          | Metadata about the record.   |  
 
 
-## Voting and comments data
+### Voting and comment data 
 
-Data on votes cast by ticket holders on a given proposal is stored in the `ballot.journal` file in the `/plugins/decred` folder. Comment data (comment content and up/down votes on comments) is stored in the `comments.journal` file in the same folder. These files are updated on the server in real-time as votes are cast and comments are made. Every hour, a git commit is made updating the `comments.journal` and (if voting has started) `ballot.journal` file ---versions of the proposal submitted prior to the version that is voted on will only have a `comments.journal` file. Commits are made every hour because making a git commit is expensive performance-wise, and making a commit for every vote and comment would not be practical. Additionally, grouping votes in hourly commits helps protect the privacy of ticketholders.
+Data on proposal comments and votes is updated hourly during the proposal's life cycle. Every hour, for each proposal in the "pre-voting" stage (proposal is open for comments, but author has not yet triggered a vote) or "active voting" stage (proposal is being voted on currently), a git commit is made updating each proposal's `comments.journal` file and (if proposal is in active voting stage) its `ballot.journal` file ---versions of the proposal submitted prior to the version that is voted on will only have a `comments.journal` file. Commits are made every hour because making a git commit is expensive performance-wise, and making a commit for every vote and comment would not be practical. Additionally, grouping votes in hourly commits helps protect the privacy of ticketholders.
 
-### ballot.journal
+### Vote data
 
-The `ballot.journal` file contains a list of votes on the proposal. The commit history for this file can be consulted to see which hour votes were cast in. The table below describes the parameters recorded for each vote. 
+Data on votes cast by ticket holders on a given proposal is stored in the `ballot.journal` file in the `/plugins/decred` folder. The commit history for this file can be consulted to see which hour votes were cast in. The table below describes the parameters recorded for each vote. 
+
+#### ballot.journal 
 
 | Parameter           | Description                   |  
 | -------------------- | ---------------------- | 
@@ -54,16 +58,18 @@ The `ballot.journal` file contains a list of votes on the proposal. The commit h
 | **signature**              |    |  
 | **receipt**             |   |  
 
-### comments.journal
 
-The `comments.journal` file contains data related to comments. The table below describes the parameters recorded for each comment.
+### Comment data 
 
+Data on comments is stored in the `comments.journal` file in the `/plugins/decred` folder. The table below describes the parameters recorded for each comment.  
+
+#### comments.journal
 
 | Parameter           | Description                   |  
 | -------------------- | ---------------------- | 
 | **action**             | The action taken by the commenter. If a comment is added, `action` = add. If a comment is voted on, `action` = addlike. If `action` = addlike, the comment action is additionally assigned '1' for upvote or '-1' for downvote.    |  
 | **token**             | The proposal being commented on.  |  
-| **parentid**             | The id of the parent comment, if a parent exists. If no parent comment exists (i.e. top-level comment), `parentid` = 0.  |  
+| **parentid**             | The id of the parent comment, or '0' if a top-level comment.  |  
 | **commentid**              |  The identifier (id) for the comment  |  
 | **timestamp**              |  A unix timestamp specifying time comment was submitted |  
 | **publickey**             |  The public key of the Politeia user who made the comment |  
@@ -73,12 +79,19 @@ The `comments.journal` file contains data related to comments. The table below d
 | **resultvotes**             |   |  
 
 
-### Identifying users
+### User data
 
-In these datasets, **Politeia users are identified by their public keys**. The method of associating a public key with a username is a little convoluted at present, in that one must start with the username. There is currently no way to look up a username from a pubkey, but that feature is planned. 
+In the datasets presented here, **users are identified by their public keys**. On [proposals.decred.org](https://proposals.decred.org/), users are identified by their username (chosen when they created their public/private key pair). 
 
-To look up the pubkeys associated with a user, click their username on proposals.decred.org to go to a page with a url like this: <https://proposals.decred.org/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
+Currently, to associate a public key with a username, you need to go through [proposals.decred.org](https://proposals.decred.org/). To look up the public key for a user, click on their username anywhere on the site. This will take you to the user's profile, which has a URL like this: 
+<https://proposals.decred.org/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
 
-The final part of this url is a UUID (universally unique ID) for the account.
 
-There is a public API which can be used to look up all of the pubkeys associated with a Politeia user account, which takes the UUID as an input. All of the public data about this user can be found at: <https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
+The final part of this URL is the Universally Unique ID (UUID) for the account. This can be input into a [public API](https://proposals.decred.org/api/v1/user/) exposed by the Politeia website, which will takes the UUID as an input and outputs user profile data, including the public key. For example, if you paste the above example UUID into a browser:
+<https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
+
+, it will return all publicly-available data for that user, including their public key:
+`"publickey":"cd6e57b93f95dd0386d670c7ce42cb0ccd1cd5b997e87a716e9359e20251994e"`
+
+
+

--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -2,101 +2,83 @@
 
 ---
 
-Data from the [proposals.decred.org](https://proposals.decred.org/) site is stored in [this repository](https://github.com/decred-proposals/mainnet). This page gives an overview of how to navigate that repository and how to interpret the contents of its files.
+Data from the [proposals.decred.org](https://proposals.decred.org/) site is stored in the [decred-proposals/mainnet](https://github.com/decred-proposals/mainnet) repo. This page provides a guide on how to navigate this repo and interpret the contents of its files.
 
-For the purpose of this guide I will be using [this proposal](https://github.com/decred-proposals/mainnet/tree/master/c68bb790ba0843980bb9695de4628995e75e0d1f36c992951db49eca7b3b4bcd/) as an example. Links from [proposals.decred.org](https://proposals.decred.org/) will take you one layer deeper to the [most recent version of the proposal](https://github.com/decred-proposals/mainnet/tree/master/c68bb790ba0843980bb9695de4628995e75e0d1f36c992951db49eca7b3b4bcd/2). 
+For the purpose of this guide we'll be using this [previous proposal](https://proposals.decred.org/proposals/c68bb790ba0843980bb9695de4628995e75e0d1f36c992951db49eca7b3b4bcd) as an example. To see data associated with this proposal, click the on the `See on GitHub` link on the proposal's page. You can also look up a proposal directly in the [decred-proposals/mainnet](https://github.com/decred-proposals/mainnet) repo using the proposal's unique hash number. For our example proposal, the hash is:
+`c68bb790ba0843980bb9695de4628995e75e0d1f36c992951db49eca7b3b4bcd`
+
+
+Below is a screenshot of the root directory of the [decred-proposals/mainnet](https://github.com/decred-proposals/mainnet) repo.  
 
 ![The root of the mainnet repository. * = proposal folders, A = anchoring data](/img/politeia/mainnet-pi-repo.png)
 
-The root of the mainnet repository. * = proposal folders, A = anchoring data.
+Folders marked with `*` contain proposal data. Folders and files marked with `A` contain anchoring data. Anchoring data relates to the anchoring of Politeia data to the Decred blockchain through dcrtime, which facilitates Politeia's transparent censorship functionality. This guide will not describe those files in detail, as they are not likely to be of interest for analysis. 
 
-The folder and file marked A relate to the anchoring of Politeia data to the Decred blockchain through dcrtime. This guide will not describe those files in detail as they are not likely to be of interest for analysis. They are functional and facilitate Politeia's transparent censorship.
+Within each proposal folder there are sequentially numbered sub-folders, one for each version of the proposal. The first folder ('/1') corresponds to the initial version of the proposal submitted to Politeia. If a proposal author updates their proposal (typically in response to community feedback), and resubmits it, that proposal and associated data is put into folder ('/2'), and so on. 
 
-Within each proposal folder there are sequentially numbered sub-folders for each version of the proposal.
+Below shows the contents of our example proposal's folder. As we can see, there are two versions of the proposal. 
 
 ![Versions of the example proposal](/img/politeia/example-proposal.png)
 
-All relevant data for the proposal can be found within the version number folder.
+If we click on the latest version ('/2'), we can see all the relevant data for this version. 
 
 ![Folder for version 2 of the example proposal](/img/politeia/prop-version2.png)
 
-**payload** folder contains an index.md file, which has the full text of the proposal and any images associated with the proposal
+Below is a table with descriptions of the files and folders found in each proposal version folder. 
 
-**plugins/decred** folder contains comments.journal (comments and up/down vote data) and, for proposals that have opened for voting, a ballot.journal file which contains ticket voting data
+| Folder/File         | Description                   |  
+| -------------------- | ---------------------- |
+| **/payload**           | Folder containing an `index.md file`, which has the full text of the proposal and any images associated with the proposal.    |  
+| **/plugins/decred**         |  Folder containing the `comments.journal` file (which contains comments and up/down vote data) and, for proposals that have opened for voting, a `ballot.journal` file, which contains ticket voting data.   |  
+| **00.metadata.txt**          | Data about the proposal submission:   <ul style="font-size: 13px"><li>timestamp</li><li>pubkey of submitter</li><li>title</li> <li>signature</li></ul> |  
+| **02.metadata.txt**           | Data about admin approval for display: <ul style="font-size: 13px"><li>timestamp</li><li>pubkey of admin</li></ul>     |  
+| **13.metadata.txt:**           | Data about proposal owner authorizing the start of voting. Where proposal owner has authorized and then rescinded authorization this will appear in multiple commits:  <ul style="font-size: 13px"><li>timestamp</li><li>owner pubkey </li><li>transaction hash</li></ul>   |  
+| **14.metadata.txt**          | Data about admin authorizing the start of voting. Includes specification of the vote: duration (2016 blocks):   <ul style="font-size: 13px"><li>quorum requirement (20%)</li><li>approval threshold (60%)</li><li>id and descriptions for voting options</li></ul> |  
+| **15.metadata.txt**          | Data about voting period:  <ul style="font-size: 13px"><li>starting block height and hash</li><li>ending block height </li><li>a list of every ticket eligible to vote on the proposal</li></ul>    |  
+| **recordmetadata.json**          | Metadata about the record.   |  
 
-**00.metadata.txt**: data about proposal submission. 
 
-* timestamp
-* pubkey of submitter 
-* title 
-* signature
+## Voting and comments data
 
-**02.metadata.txt**: data about admin approval for display. 
+Data on votes cast by ticket holders on a given proposal is stored in the `ballot.journal` file in the `/plugins/decred` folder. Comment data (comment content and up/down votes on comments) is stored in the `comments.journal` file in the same folder. These files are updated on the server in real-time as votes are cast and comments are made. Every hour, a git commit is made updating the `comments.journal` and (if voting has started) `ballot.journal` file ---versions of the proposal submitted prior to the version that is voted on will only have a `comments.journal` file. Commits are made every hour because making a git commit is expensive performance-wise, and making a commit for every vote and comment would not be practical. Additionally, grouping votes in hourly commits helps protect the privacy of ticketholders.
 
-* timestamp 
-* pubkey of admin
+### ballot.journal
 
-**13.metadata.txt:** data about proposal owner authorizing the start of voting. Where proposal owner has authorized and then rescinded authorization this will appear in multiple commits.
+The `ballot.journal` file contains a list of votes on the proposal. The commit history for this file can be consulted to see which hour votes were cast in. The table below describes the parameters recorded for each vote. 
 
-* timestamp
-* owner pubkey 
-* transaction hash 
+| Parameter           | Description                   |  
+| -------------------- | ---------------------- | 
+| **token**              | The proposal being voted on    |  
+| **ticket**              | The ticket which is voting   |  
+| **votebit**             | Whether the vote was Yes (2) or No (1)   |  
+| **signature**              |    |  
+| **receipt**             |   |  
 
-**14.metadata.txt**: data about admin authorizing the start of voting. Includes specification of the vote:
-duration (2016 blocks)
+### comments.journal
 
-* quorum requirement (20%)
-* approval threshold (60%)
-* id and descriptions for voting options
+The `comments.journal` file contains data related to comments. The table below describes the parameters recorded for each comment.
 
-**15.metadata.txt**: data about voting period. 
 
-* starting block height and hash
-* ending block height 
-* a list of every ticket eligible to vote on the proposal
+| Parameter           | Description                   |  
+| -------------------- | ---------------------- | 
+| **action**             | The action taken by the commenter. If a comment is added, `action` = add. If a comment is voted on, `action` = addlike. If `action` = addlike, the comment action is additionally assigned '1' for upvote or '-1' for downvote.    |  
+| **token**             | The proposal being commented on.  |  
+| **parentid**             | The id of the parent comment, if a parent exists. If no parent comment exists (i.e. top-level comment), `parentid` = 0.  |  
+| **commentid**              |  The identifier (id) for the comment  |  
+| **timestamp**              |  A unix timestamp specifying time comment was submitted |  
+| **publickey**             |  The public key of the Politeia user who made the comment |  
+| **censored**             |  The censorship status. If the comment has been censored, `censored` = true, and the comment will not be shown on proposals.decred.org.  |  
+| **receipt**             |   |  
+| **totalvotes**            |   |  
+| **resultvotes**             |   |  
 
-**recordmetadata.json**: 
 
-The plugins/decred files warrant further explanation.
+### Identifying users
 
-The ballot and comment journal files are updated on the server in real time as votes are cast and comments are made. Every hour, a git commit is made for the latest journal file changes. Making a git commit is expensive performance wise so making a new commit every time a comment was made or a vote was cast would not be practical.
-
-**ballot.journal**
-
-This file contains a list of votes on the proposal. The commit history can be consulted to see which hour votes were cast in.
-
-- **token** is the proposal being voted on
-- **ticket** is the ticket which is voting
-- **votebit** shows whether the vote was Yes (2) or No (1)
-- **signature**
-- **receipt**
-
-**comments.journal**
-
-This file contains two types of row
-
-**action:add** rows describe the addition of comments.
-
-* **token** is the proposal being commented on
-* **parentid** is either 0 for top-level comments, or the comment_id of the comment which is being responded to
-* **commentid** is an identifier for each comment
-* **comment** is the body (text) of the comment
-* **timestamp** is a unix timestamp for when the comment was made
-* **publickey** is the public key of the Politeia user who made the comment
-* **censored** records whether the comment has been censored, where censored == true the comment will not be shown on proposals.decred.org
-* **signature** 
-* **receipt**
-* **totalvotes**
-* **resultvotes**
-
-**action:addLike** rows describe the addition of up/down votes on comments, many of the fields have the same meaning as for action:add rows. 
-
-* **action** can be either 1 (upvote) or -1 (downvote)
-
-In these data-sets, **Politeia users are identified by their public keys**. The method of associating a public key with a username is a little convoluted at present, in that one must start with the username. There is currently no way to look up a username from a pubkey, but that feature will be added.
+In these datasets, **Politeia users are identified by their public keys**. The method of associating a public key with a username is a little convoluted at present, in that one must start with the username. There is currently no way to look up a username from a pubkey, but that feature is planned. 
 
 To look up the pubkeys associated with a user, click their username on proposals.decred.org to go to a page with a url like this: <https://proposals.decred.org/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
 
 The final part of this url is a UUID (universally unique ID) for the account.
 
-There is a public API which can be used to look up all of the pubkeys associated with a Politeia user account, it takes the UUID as an input. All of the public data about this user can be found at: <https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
+There is a public API which can be used to look up all of the pubkeys associated with a Politeia user account, which takes the UUID as an input. All of the public data about this user can be found at: <https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>

--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -87,11 +87,8 @@ In the datasets presented here, **users are identified by their public keys**. O
 Currently, to associate a public key with a username, you need to go through [proposals.decred.org](https://proposals.decred.org/). To look up the public key for a user, click on their username anywhere on the site. This will take you to the user's profile, which has a URL like this: 
 <https://proposals.decred.org/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
 
-The final part of this URL is the Universally Unique ID (UUID) for the account. This can be input into a [public API](https://proposals.decred.org/api/v1/user/) exposed by the Politeia website, which will takes the UUID as an input and outputs user profile data, including the public key. For example, if you paste the above example UUID into a browser:
-<https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
-
-, it will return all publicly-available data for that user, including their public key:
-`"publickey":"cd6e57b93f95dd0386d670c7ce42cb0ccd1cd5b997e87a716e9359e20251994e"`
+The final part of this URL is the Universally Unique ID (UUID) for the account. This can be input into a [public API](https://proposals.decred.org/api/v1/user/) exposed by the Politeia website, which will takes the UUID as an input and outputs user profile data, including the public key. For example, if you paste the above example UUID into a browser,
+<https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>, it will return all publicly-available data for that user, including their public key: `"publickey":"cd6e57b93f95dd0386d670c7ce42cb0ccd1cd5b997e87a716e9359e20251994e"`
 
 
 

--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -42,7 +42,8 @@ Below is a table with descriptions of the files and folders found in each propos
 
 ### Voting and comment data 
 
-Data on proposal comments and votes is updated hourly during the proposal's life cycle. Every hour, for each proposal in the "pre-voting" stage (proposal is open for comments, but author has not yet triggered a vote) or "active voting" stage (proposal is being voted on currently), a git commit is made updating each proposal's `comments.journal` file and (if proposal is in active voting stage) its `ballot.journal` file ---versions of the proposal submitted prior to the version that is voted on will only have a `comments.journal` file. Commits are made every hour because making a git commit is expensive performance-wise, and making a commit for every vote and comment would not be practical. Additionally, grouping votes in hourly commits helps protect the privacy of ticketholders.
+A git commit is made every hour for each active proposal to update the `comments.journal` file. If voting has started on a proposal, the same commit will also be used to update its `ballot.journal` file. The hourly commits are stopped once the voting has been completed and all votes have been recorded in git. Commits are made every hour because making a git commit is expensive performance-wise and making a commit for every vote and comment would not be practical. Additionally, grouping votes in hourly commits helps protect the privacy of ticketholders.
+
 
 ### Vote data
 
@@ -85,7 +86,6 @@ In the datasets presented here, **users are identified by their public keys**. O
 
 Currently, to associate a public key with a username, you need to go through [proposals.decred.org](https://proposals.decred.org/). To look up the public key for a user, click on their username anywhere on the site. This will take you to the user's profile, which has a URL like this: 
 <https://proposals.decred.org/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>
-
 
 The final part of this URL is the Universally Unique ID (UUID) for the account. This can be input into a [public API](https://proposals.decred.org/api/v1/user/) exposed by the Politeia website, which will takes the UUID as an input and outputs user profile data, including the public key. For example, if you paste the above example UUID into a browser:
 <https://proposals.decred.org/api/v1/user/350a4b6c-5cdd-4d87-822a-4900dc3a930c>


### PR DESCRIPTION
Cleanup and formatting specified in original PR ( Closes #698 ). 

In addition to basic cleanup (replacing bulleted lists w/ tables, removing double spaces), did some rewording for flow, and added two new subheadings for organization. 
