### PR TITLE
Fixes capitalization governance pages

### DIFF
--- a/docs/governance/consensus-rules-voting.md
+++ b/docs/governance/consensus-rules-voting.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus rules voting
+# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus Rules Voting
 
 This guide was last updated on September 23, 2017.
 

--- a/docs/governance/introduction-to-decred-governance.md
+++ b/docs/governance/introduction-to-decred-governance.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Governance.svg" /> Introduction to Decred governance
+# <img class="dcr-icon" src="/img/dcr-icons/Governance.svg" /> Introduction to Decred Governance
 
 ---
 

--- a/docs/governance/politeia.md
+++ b/docs/governance/politeia.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Politeia proposals and voting
+# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Politeia Proposals and Voting
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,9 +44,9 @@ nav:
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
 - Governance:
   - 'Introduction to Decred governance': 'governance/introduction-to-decred-governance.md'
-  - 'Consensus rules voting': 'governance/consensus-rules-voting.md'
-  - 'How to Vote on consensus rule changes': 'governance/how-to-vote.md'
-  - 'Politeia proposals and voting': 'governance/politeia.md'
+  - 'Consensus Rules Voting': 'governance/consensus-rules-voting.md'
+  - 'How to Vote on Consensus Rule Changes': 'governance/how-to-vote.md'
+  - 'Politeia Proposals and Voting': 'governance/politeia.md'
   - 'Decred Constitution': 'governance/decred-constitution.md'
 - Wallets:
     - Decrediton (GUI):


### PR DESCRIPTION
Capitalizes all significant words in titles for two pages in the governance section, making these pages consistent with the rest of the pages in dcrdocs ( Closes #714 ).

