### PR TITLE
Updates outdated stakepool logo

### DIFF
--- a/docs/faq/proof-of-stake/stake-pools.md
+++ b/docs/faq/proof-of-stake/stake-pools.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Pool.svg" /> Voting Service Providers
+# <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> Voting Service Providers
 
 ---
 

--- a/docs/governance/how-to-vote.md
+++ b/docs/governance/how-to-vote.md
@@ -4,7 +4,7 @@ This guide assumes you already have an active wallet and have purchased tickets.
 
 The choice a ticket votes with depends on your vote preference at the time the ticket is chosen, not when it is bought. So you can set your choice at any time within the voting window and all future tickets will vote accordingly.
 
-## <img class="dcr-icon" src="/img/dcr-icons/Pool.svg" /> **Voting with a Voting Service Provider (VSP)**
+## <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> **Voting with a Voting Service Provider (VSP)**
 
 If your Voting Service Provider (VSP) has updated to the latest VSP software, you will find a 'Voting' page in the navigation menu with dropdown options for each agenda. After you've chosen how you want your tickets to vote, simply press the 'Update Voting Preferences' button to save your vote choices. Below you'll find an image of the vote choices for vote version 5.
 

--- a/docs/mining/how-to-stake.md
+++ b/docs/mining/how-to-stake.md
@@ -18,7 +18,7 @@ Solo PoS voting is currently only possible using the Decred command line tools. 
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Pool.svg" /> PoS using a Voting Service Provider (VSP)
+## <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> PoS using a Voting Service Provider (VSP)
 
 A list of Voting Service Providers (VSPs) and statistics is maintained on the
 [:fa-external-link-square: Decred.org website](https://decred.org/stakepools/).

--- a/docs/research/decentralized-stake-pooling.md
+++ b/docs/research/decentralized-stake-pooling.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Pool.svg" /> Decentralized Stake Pooling 
+# <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> Decentralized Stake Pooling 
 
 ---
 


### PR DESCRIPTION
Replaces all instances of `Pool.svg` icon with `Servers.svg` icon, to reflect jargon change ( "Stakepool" -> "Voting Service Provider") ( Closes #740 ). 