### PR TITLE
Remove site_url config.

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -4,7 +4,7 @@ dcrdocs is licensed under the [copyfree](http://copyfree.org) ISC License.
 
 ---
 
-Copyright © 2013-2015 The btcsuite developers. Copyright © 2015-2017 The Decred developers.
+Copyright © 2013-2015 The btcsuite developers. Copyright © 2015-2019 The Decred developers.
 
 Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ extra:
       link: 'https://www.facebook.com/decredproject/'
     - type: 'weibo'
       link: 'https://weibo.com/DecredProject'
-site_url: https://docs.decred.org
 repo_url: https://github.com/decred/dcrdocs
 repo_name: decred/dcrdocs
 markdown_extensions:
@@ -121,4 +120,4 @@ nav:
   - 'Credits': 'about/credits.md'
   - 'License': 'about/license.md'
 - 'Glossary': 'glossary.md'
-copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new"><i class="fa fa-github"></i> open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare"><i class="fa fa-github"></i> send a pull request</a>.<br>dcrdocs v0.0.3. Decred Project 2018.
+copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new"><i class="fa fa-github"></i> open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare"><i class="fa fa-github"></i> send a pull request</a>.<br>dcrdocs v0.0.3. Decred Project 2019.


### PR DESCRIPTION
Two benefits of removing this:
- Site works better when running in different locations (eg. locally) - All links default to the current instance (`/`) rather than some of them pointing incorrectly to docs.decred.org
- Fixes the 404 page (ref. https://github.com/mkdocs/mkdocs/issues/1598) (Closes #787)

One drawback:
-The only significant feature depending on this config is canonical links in the HTML headers. I consider this an acceptable loss - we don't need canonical links because we only host the docs in one place.