### PR TITLE
Adds address details page

### DIFF
--- a/docs/advanced/address-details.md
+++ b/docs/advanced/address-details.md
@@ -8,11 +8,9 @@ The most commonly used address currently is the Pay-to-PubkeyHash (P2PKH) type, 
 
 ## Address format
 
-Each address has a 2-byte prefix than can be used to identify its type. The first byte of the prefix identifies the network. Mainnet addresses start with `D`, testnet addresses start with `T`, simnet addresses start with `S`, and regnet addresses start with `R`. The second byte identifies the address type. Pay-to-PubkeyHash (P2PKH) addresses, for example, contsin a lowercase `s` in the second byte. So, a P2PKH address on mainnet will begin with`Ds`, as shown in the sample address below.  
+Each address has a 2-byte prefix than can be used to identify its type, and a checksum suffix to detect improperly entered addresses. The first byte of the prefix identifies the network. Mainnet addresses start with `D`, testnet addresses start with `T`, simnet addresses start with `S`, and regnet addresses start with `R`. The second byte identifies the address type. Pay-to-PubkeyHash (P2PKH) addresses, for example, contsin a lowercase `s` in the second byte. So, a P2PKH address on mainnet will begin with`Ds`, as shown in the sample address below.  
 
-```DsYszZ5n79HJzyTVGAdXeDb1b3Z5N2Tnsij```
-
-
+```DsExampleAddr1For2Demo3PurposesOnly```
 
 The table below provides the locking script and prefix details for each address type. 
 

--- a/docs/advanced/address-details.md
+++ b/docs/advanced/address-details.md
@@ -1,0 +1,31 @@
+# <img class="dcr-icon" src="/img/dcr-icons/Transactions.svg" /> Address Details 
+
+---
+
+A Decred address is a representation of a public key, which itself could be a script hash. 
+
+The most commonly used address currently is the Pay-to-PubkeyHash (P2PKH) type, which is used to send DCR to a single address. For this address type, the recipient must provide both the public key which hashes to the requisite hash, and a valid signature that is created from the corresponding private key. Other address types require signatures from multiple parties (multi-sig), signatures created within specified time limits, or other more complex constraints. Pay-to-Script-Hash (P2SH) addresses, for example, generate a 1-of-2 multisig transaction utilized by Voting Service Providers (VSPs) that allow VSPs to vote on behalf of ticket holders. In this case, both the ticket holder and VSP have their own private keys, allowing either to vote. 
+
+## Address format
+
+Each address has a 2-byte prefix than can be used to identify its type. The first byte of the prefix identifies the network. Mainnet addresses start with `D`, testnet addresses start with `T`, simnet addresses start with `S`, and regnet addresses start with `R`. The second byte identifies the address type. Pay-to-PubkeyHash (P2PKH) addresses, for example, contsin a lowercase `s` in the second byte. So, a P2PKH address on mainnet will begin with`Ds`, as shown in the sample address below.  
+
+```DsYszZ5n79HJzyTVGAdXeDb1b3Z5N2Tnsij```
+
+
+
+The table below provides the locking script and prefix details for each address type. 
+
+
+Address Type        | Locking Script | Mainnet	| Testnet |	Simnet | Regnet	| Prefix Size (byte) |
+| ---          | --- | --- |  --- |  --- |  --- |  --- |    
+Pay-to-Pubkey	| P2Pk | Dk |	Tk |	Sk |	Rk | 2 |
+Pay-to-PubkeyHash |	P2PKH	| Ds	| Ts	| Ss |	Rs |	2 |
+Pay-to-PubkeyHash <br> (Edwards Address ID) |		P2PKH |		De |		Te |		Se	 |	Re |	2 |	
+Pay-to-PubkeyHash <br> (secp256k1 Schnorr Address ID) |	P2PKH |	DS |	TS |	SS |	RS |	2 |
+Pay-to-Script-Hash |	P2SH |	Dc |	Tc |	Sc |	Rc |	2 |
+Wallet Import format <br> (Private Key ID) |	WIF |	Pm |	Pt |	Ps |	Pr |	2 |
+Hierarchical deterministic <br>(Private Key ID) |	HD |	dprv |	tprv |	sprv |	rprv |	4 |
+Hierarchical deterministic <br> (Public Key ID) |	HD |	dpub |	tpub |	spub |	rpub |	4 |
+
+

--- a/docs/advanced/address-details.md
+++ b/docs/advanced/address-details.md
@@ -8,7 +8,7 @@ The most commonly used address currently is the Pay-to-PubkeyHash (P2PKH) type, 
 
 ## Address format
 
-Each address has a 2-byte prefix than can be used to identify its type, and a checksum suffix to detect improperly entered addresses. The first byte of the prefix identifies the network. Mainnet addresses start with `D`, testnet addresses start with `T`, simnet addresses start with `S`, and regnet addresses start with `R`. The second byte identifies the address type. Pay-to-PubkeyHash (P2PKH) addresses, for example, contsin a lowercase `s` in the second byte. So, a P2PKH address on mainnet will begin with`Ds`, as shown in the sample address below.  
+Each address has a 2-byte prefix than can be used to identify its type, and a checksum suffix to detect improperly entered addresses. The first byte of the prefix identifies the network. Mainnet addresses start with `D`, testnet addresses start with `T`, simnet addresses start with `S`, and regnet addresses start with `R`. The second byte identifies the address type. Pay-to-PubkeyHash (P2PKH) addresses, for example, contain a lowercase `s` in the second byte. So, a P2PKH address on mainnet will begin with`Ds`, as shown in the sample address below.  
 
 ```DsExampleAddr1For2Demo3PurposesOnly```
 

--- a/docs/faq/wallets-and-seeds.md
+++ b/docs/faq/wallets-and-seeds.md
@@ -70,27 +70,7 @@ A public key address, also called Pay-To-Pubkey (P2Pk), can be identified with i
 
 #### 8. What are the different types of addresses?
 
-A Decred address[^14995] is actually just a representation of a public key (which itself could be a script hash) along with a 2-byte prefix which identifies the network and type and a checksum suffix in order to detect improperly entered addresses.
-
-Consequently, you can always tell what type of address it is based on the 2-byte prefix.
-
-The first byte of the prefix identifies the network. This is why all mainnet addresses start with "D", testnet addresses start with "T", and simnet addresses start with "S". 
-
-|        	| (Decred) Mainnet 	| Testnet 	| Simnet 	|
-|--------	|:----------------:	|:-------:	|:-------:	|
-| Prefix 	|         D        	|    T    	|    S   	|
-
-The second byte of the prefix identifies the type of address it is. The most common addresses used at the moment are secp256k1 pubkey hashes, which are identified by a lowercase "s". It represents a single public key and therefore only has a single associated private key which can be used to redeem it.
-
-Voting Service Providers (VSPs) use pay-to-script-hash addresses, which are identified by the second byte being a lowercase "c" (again that is shown in the linked params). The specific flavor of script it generates is a multi-signature 1-of-2, which is how it allows either the VSP, or you, to vote. Both you and the VSP have your own private keys and since the script only requires one signature of the possible two, that is how it allows delegation of voting rights to the VSP without you giving up your voting rights completely.
-
-| Address   Type     	| Locking   Script 	| (Decred) Mainnet  	| Testnet 	| Simnet 	| Prefix Size (byte) 	|
-|--------------------	|:----------------:	|:-----------------:	|:--------:	|:------:	|:------------------:	|
-| Pay-to-Pubkey      	|       P2Pk       	|         Dk        	|    Tk   	|   Sk   	|    2                  	|
-| Pay-to-Pubkey-Hash (secp256k1)  	|       P2PKH      	|         Ds        	|    Ts   	|   Ss   	|    2                  	|
-| Pay-to-Script-Hash 	|       P2SH       	|         Dc        	|    Tc   	|   Sc   	|    2                  	|
-
----
+The most commonly used address currently is the Pay-to-PubkeyHash (P2PKH) type, which is used to send DCR to a single address. Other address types require signatures from multiple parties (multi-sig), signatures created within specified time limits, or other more complex constraints. For details on various address types, see the see the [address details](../advanced/address-details.md) page.  
 
 #### 9. I have lost my seed. What can I do?
 

--- a/docs/faq/wallets-and-seeds.md
+++ b/docs/faq/wallets-and-seeds.md
@@ -64,7 +64,7 @@ dcrctl --wallet getbalance "imported" 0 all
 
 #### 7. What is the difference between a testnet and mainnet public key address?
 
-A public key address, also called Pay-To-Pubkey (P2Pk), can be identified with its 2-byte prefix which identifies the network and type. A mainnet public key address starts with the letters `Dk` while a testnet public key address starts with the letters `Tk`. For details on address types, see the see the [address details](advanced/address-details.md) page.  
+A public key address, also called Pay-To-Pubkey (P2Pk), can be identified with its 2-byte prefix which identifies the network and type. A mainnet public key address starts with the letters `Dk` while a testnet public key address starts with the letters `Tk`. For details on address types, see the see the [address details](../advanced/address-details.md) page.  
 
 ---
 

--- a/docs/faq/wallets-and-seeds.md
+++ b/docs/faq/wallets-and-seeds.md
@@ -64,13 +64,9 @@ dcrctl --wallet getbalance "imported" 0 all
 
 #### 7. What is the difference between a testnet and mainnet public key address?
 
-A public key address, also called Pay-To-Pubkey (P2Pk), can be identified with its 2-byte prefix which identifies the network and type. A mainnet public key address starts with the letters `Dk` while a testnet public key address[^11507] starts with the letters `Tk`. 
+A public key address, also called Pay-To-Pubkey (P2Pk), can be identified with its 2-byte prefix which identifies the network and type. A mainnet public key address starts with the letters `Dk` while a testnet public key address starts with the letters `Tk`. For details on address types, see the see the [address details](advanced/address-details.md) page.  
 
 ---
-
-#### 8. What are the different types of addresses?
-
-The most commonly used address currently is the Pay-to-PubkeyHash (P2PKH) type, which is used to send DCR to a single address. Other address types require signatures from multiple parties (multi-sig), signatures created within specified time limits, or other more complex constraints. For details on various address types, see the see the [address details](../advanced/address-details.md) page.  
 
 #### 9. I have lost my seed. What can I do?
 
@@ -91,5 +87,4 @@ You should backup your `wallet.db` file (preferably in a thumb drive stored in a
 [^10452]: Decred Forum, [Post 10,452](https://forum.decred.org/threads/734/#post-10452)
 [^10657]: Decred Forum, [Post 10,657](https://forum.decred.org/threads/483/#post-10657)
 [^10724]: Decred Forum, [Post 10,724](https://forum.decred.org/threads/643/page-3#post-10724)
-[^11507]: Decred Forum, [Post 11,507](https://forum.decred.org/threads/792/#post-11507)
-[^14995]: Decred Forum, [Post 14,995](https://forum.decred.org/threads/1321/page-2#post-14995)
+

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -11,7 +11,8 @@ Accounts allow you to keep separate records of your DCR funds. Transferring DCR 
 
 #### Address
 
-A human-readable representation of a possible destination for a payment, similar to an email address. Unlike an email address however, there are a variety of address types, and most addresses are intended only for a single use. This is because addresses represent not only the destination of a payment, but constraints required to redeem funds. For the most common type of address, the constraints require that the recipient provide both the public key which hashes to the requisite hash and a valid signature that is created from the corresponding private key. Other address types require signatures from multiple parties (multi-sig), signatures created within specified time limits, or other more complex constraints.
+A human-readable representation of a possible destination for a payment, similar to an email address. Unlike an email address however, there are a variety of address types, and most addresses are intended only for a single use. This is because addresses represent not only the destination of a payment, but constraints required to redeem funds. For more on addresses see the [address details](advanced/address-details.md) page.  
+
 
 #### Atom
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - 'Blocks': 'faq/blocks.md'
   - 'Common Errors and Solutions': 'faq/errors.md'
 - Advanced:
+  - 'Address Details': advanced/address-details.md
   - 'Using Testnet': 'advanced/using-testnet.md'
   - 'Manual CLI Installation': 'advanced/manual-cli-install.md'
   - 'Block Header Specifications': 'advanced/block-header-specifications.md'


### PR DESCRIPTION
This PR creates a 'Address details' page under /Advanced ( Closes #779 , Closes #710 ). Previously, technical details about addresses were found in the glossary definition for Address and a couple FAQ questions. An advanced page seemed like a better place to aggregate this information. Have also added the table @zubairzia0 added in Issue https://github.com/decred/dcrdocs/issues/710 (@jholdstock maybe this finally closes that issue?). The glossary definition of address and relevant FAQ questions have also been updated to be more concise and point to the new address page. 

