### PR TITLE
Link to community page instead of listing irc/slack.

### DIFF
--- a/docs/contributing/source-code-contributions.md
+++ b/docs/contributing/source-code-contributions.md
@@ -62,4 +62,4 @@ $ git remote add <yourname> https://github.com/<yourname>/dcrdocs.git
 
 There are a few other things to consider when doing a pull request.  In the case of the Go code, there is significant test coverage already.  If you are adding code, you should add tests as well.  If you are fixing something, you need to make sure you do not break any existing tests.  For the Go code, there is a script ```goclean.sh``` in each repo to run the tests and the any static checkers we have.  NO code will be accepted without passing all the tests.  In the case of the node.js code (decrediton) all code must pass eslint.  You can check this with the command ```npm run lint```.
 
-If you have any questions for contributing, feel free to ask on irc/slack or GitHub.  Decred team members (and probably community members too) will be happy to help.
+If you have any questions for contributing, feel free to contact the [Decred community](https://decred.org/community).  Decred team members (and probably community members too) will be happy to help.

--- a/docs/contributing/using-github.md
+++ b/docs/contributing/using-github.md
@@ -17,7 +17,7 @@ Our model for contributing in outline form is as follows. If any of this does no
 1. Push these changes to your own forked GitHub repo.
 1. When your changes are ready to be reviewed or when you just want input from other devs open a Pull Request (PR) on the main repo from the GitHub web page.
 1. Add a comment on the PR that says what issue you are fixing. Put the text Closes # or Fixes # followed by the number of the issue on a single line. This will allow GitHub to automatically link the PR to the issue and close the issue when the PR is closed.
-1. You can request a specific reviewer from the GitHub webpage or you can ask someone on IRC/Slack to review.
+1. You can request a specific reviewer from the GitHub webpage or you can join the [Decred community](https://decred.org/community) and ask somebody to review.
 1. ALL changes must be reviewed and receive at least one approval before they can go in. Only team members can give official approval, but comments from other users are encouraged.
 1. If there are changes requested, make those changes and commit them to your local branch.
 1. Push those changes to the same branch you have been working on. They will show up in the PR that way and the reviewer can then compare to the previous version.
@@ -40,7 +40,7 @@ $ git checkout -b <feature_branch>
 $ git push <yourname> <feature_branch>
 ```
 - With your browser, navigate to https://github.com/decred/dcrd
-- Create a pull request with the GitHub UI. You can request a reviewer on the GitHub web page or you can ask someone on irc/slack.
+- Create a pull request with the GitHub UI. You can request a reviewer on the GitHub web page or you can join the [Decred community](https://decred.org/community) and ask somebody to review.
 
 ## Rebasing one of your existing pull requests 
 
@@ -73,4 +73,4 @@ $ git push -f <yourname> <feature_branch>
 
 Each GitHub repo has a LICENSE. Your new code must be under the same LICENSE as the existing code and assigned copyright to 'The Decred Developers'. In most cases this is the very liberal ISC license but a few repos are different. Check the repo to be sure.
 
-If you have any questions for contributing, feel free to ask on irc/slack or GitHub. Decred team members (and probably community members too) will be happy to help.
+If you have any questions for contributing, feel free to contact the [Decred community](https://decred.org/community).  Decred team members (and probably community members too) will be happy to help.

--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -61,7 +61,7 @@ The following chat platforms are bridged, such that one's messages are relayed t
 * [Discord](https://discord.gg/GJ2GXfz)
 * [IRC](https://webchat.freenode.net/?channels=decred&uio=d4)
 
-Telegram, Rocket.Chat and KakaoTalk are partially bridged.
+Telegram and KakaoTalk are partially bridged.
 
 ### Social Media
 


### PR DESCRIPTION
Also removes Rocket chat, as we removed it from https://decred.org/community
Closes #447 