### PR TITLE
Move voting archive into its own page.

### DIFF
--- a/docs/faq/proof-of-stake/general.md
+++ b/docs/faq/proof-of-stake/general.md
@@ -112,7 +112,7 @@ Currently, a platform for the community to submit and advocate a voting agenda i
 
 #### 10. What is hardfork voting? 
 
-A more up-to-date version of this information, with a diagram, is available on [consensus rules voting](../../governance/consensus-rules-voting.md) page.
+A more up-to-date version of this information, with a diagram, is available on [consensus rules voting](../../governance/consensus-rule-voting/consensus-rules-voting.md) page.
 
 Like any other cryptocurrency, Decred might need to hardfork at some point.
 

--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -21,7 +21,7 @@ The following guides go into depth on key aspects of the Decred experience:
 * [Governance](../governance/introduction-to-decred-governance.md)
 * [Ticket buying guide](../proof-of-stake/proof-of-stake.md)
 * [Politeia](../governance/politeia/politeia.md)
-* [Voting on consensus rules changes](../governance/consensus-rules-voting.md)
+* [Voting on consensus rules changes](../governance/consensus-rule-voting/consensus-rules-voting.md)
 * [Using Testnet](../advanced/using-testnet.md)
 
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -79,7 +79,7 @@ Rules, encoded in software, that allow a network of nodes to reach an agreement 
 
 #### Consensus rules voting
 
-Changes to Decred's consensus rules can only be made through an [on-chain voting process](governance/consensus-rules-voting.md) which lasts for around one month. The change is made only if at least 75% of votes are in favor. 
+Changes to Decred's consensus rules can only be made through an [on-chain voting process](governance/consensus-rule-voting/consensus-rules-voting.md) which lasts for around one month. The change is made only if at least 75% of votes are in favor.
 
 #### Constitution
 

--- a/docs/governance/consensus-rule-voting/consensus-rules-voting.md
+++ b/docs/governance/consensus-rule-voting/consensus-rules-voting.md
@@ -26,17 +26,18 @@ There are a few possible outcomes of a vote:
 
 Below is a diagram of the entire cycle for a single agenda with consensus upgrades.
 
-<img src="/img/voting-cycle.png">
+
+![Consensus rule voting cycle](/img/voting-cycle.png)
 
 ---
 
 ## Voting Preparation
 
-To participate in voting, you first need a wallet. If you don't have one already, visit the [Beginner Guide](../getting-started/beginner-guide.md), choose a wallet, and follow the installation and setup guides.
+To participate in voting, you first need a wallet. If you don't have one already, visit the [Beginner Guide](../../getting-started/beginner-guide.md), choose a wallet, and follow the installation and setup guides.
 
-Next, you'll need to learn the basics of [Proof-of-Stake](../proof-of-stake/proof-of-stake.md). You'll need to be able to [buy tickets](../proof-of-stake/how-to-stake.md) with your application of choice.
+Next, you'll need to learn the basics of [Proof-of-Stake](../../proof-of-stake/proof-of-stake.md). You'll need to be able to [buy tickets](../../proof-of-stake/how-to-stake.md) with your application of choice.
 
-Finally, you'll need to learn how to set the `votechoice` for your tickets in order to cast a "Yes", "No", or "Abstain" vote for an agenda. By default, your tickets will cast "Abstain" votes. To set your vote choice, see our quick [How To Vote](how-to-vote.md).
+Finally, you'll need to learn how to set the `votechoice` for your tickets in order to cast a "Yes", "No", or "Abstain" vote for an agenda. By default, your tickets will cast "Abstain" votes. To set your vote choice, see our quick [How To Vote](../how-to-vote.md).
 
 ---
 
@@ -46,76 +47,10 @@ The easiest method to track your how your tickets actually voted is to use the [
 
 The block explorer has been updated to display "YES", "NO", and "ABSTAIN" votes for each agenda with each ticket. The first and second tickets in the following example image voted "ABSTAIN" for both agendas while the third ticket voted "YES" for both agendas. The image will be updated to reflect the v5 agenda when voting is live.
 
-<img src="/img/verify_block-explorer-votes.png">
+![Verifying votes on the block explorer](/img/verify_block-explorer-votes.png)
 
 ---
 
 ## Tracking Vote Progress
 
 [voting.decred.org](https://voting.decred.org) is an official website set up to track the progress of upgrading and voting.
-
----
-
-## Voting Archive
-
-This section provides an archive for previous votes along with their outcomes.
-
-#V4#
-
-## Change PoS Staking Algorithm
-**Agenda ID:**  sdiffalgorithm
-
-Change stake difficulty algorithm as defined in DCP0001
-
-Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals.
-
-## Voting Results: 
-
-| Choice  | Result
-|-----|-------|
-|No   |  2.07%|
-|Yes  | 97.92%|
-
-**Locked In:** 141184<br />
-**Activated:** 149248<br />
-**Hard Forked:** 149328
-
-
-## Start Lightning Network Support
-**Agenda ID:**  lnsupport
-
-Request developers begin work on Lightning Network (LN) integration
-
-The Lightning Network is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.
-
-##Voting Results:
-
-| Choice  | Result
-|-----|-------|
-|No   |  1.38%|
-|Yes  | 98.61%|
-
-**Locked In:** 141184<br />
-**Activated:** 149248
-
-
-#V5#
-
-## Activation of new opcodes for Lightning Network Support
-**Agenda ID:** lnfeatures
-
-Enable features defined in [DCP0002](https://github.com/decred/dcps/blob/master/dcp-0002/dcp-0002.mediawiki) and [DCP0003](https://github.com/decred/dcps/blob/master/dcp-0003/dcp-0003.mediawiki) necessary to support Lightning Network (LN)
-
-The Lightning Network is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.
-
-Block 205189 is the first block which contains the new opcode which was voted in via the lnfeatures vote and thus all old nodes must upgrade.
-
-##Voting Results:
-
-| Choice  | Result
-|-----|-------|
-|No   |  0.49%|
-|Yes  | 99.51%|
-
-**Locked In:** 181504<br />
-**Activated:** 189568

--- a/docs/governance/consensus-rule-voting/consensus-vote-archive.md
+++ b/docs/governance/consensus-rule-voting/consensus-vote-archive.md
@@ -1,0 +1,74 @@
+# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus Vote Archive
+
+
+This section provides an archive for previous votes along with their outcomes.
+
+---
+
+## V4
+
+### Change PoS Staking Algorithm
+
+**Agenda ID:**  sdiffalgorithm
+
+Change stake difficulty algorithm as defined in DCP0001
+
+Specifies a proposed replacement algorithm for determining the stake difficulty (commonly called the ticket price). This proposal resolves all issues with a new algorithm that adheres to the referenced ideals.
+
+#### Voting Results
+
+| Choice | Result |
+|--------|--------|
+|No      |  2.07% |
+|Yes     | 97.92% |
+
+**Locked In:** 141184
+
+**Activated:** 149248
+
+**Hard Forked:** 149328
+
+
+### Start Lightning Network Support
+
+**Agenda ID:**  lnsupport
+
+Request developers begin work on Lightning Network (LN) integration
+
+The Lightning Network is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.
+
+#### Voting Results
+
+| Choice | Result |
+|--------|--------|
+|No      |  1.38% |
+|Yes     | 98.61% |
+
+**Locked In:** 141184
+
+**Activated:** 149248
+
+---
+
+## V5
+
+### Activation of new opcodes for Lightning Network Support
+
+**Agenda ID:** lnfeatures
+
+Enable features defined in [DCP0002](https://github.com/decred/dcps/blob/master/dcp-0002/dcp-0002.mediawiki) and [DCP0003](https://github.com/decred/dcps/blob/master/dcp-0003/dcp-0003.mediawiki) necessary to support Lightning Network (LN)
+
+The Lightning Network is the most directly useful application of smart contracts to date since it allows for off-chain transactions that optionally settle on-chain. This infrastructure has clear benefits for both scaling and privacy. Decred is optimally positioned for this integration.
+
+Block 205189 is the first block which contains the new opcode which was voted in via the lnfeatures vote and thus all old nodes must upgrade.
+
+#### Voting Results
+
+| Choice | Result |
+|--------|--------|
+|No      |  0.49% |
+|Yes     | 99.51% |
+
+**Locked In:** 181504
+
+**Activated:** 189568

--- a/docs/governance/how-to-vote.md
+++ b/docs/governance/how-to-vote.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> **How to Vote on consensus rule changes**
 
-This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](consensus-rules-voting.md#voting-preparation) guide.
+This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](consensus-rule-voting/consensus-rules-voting.md#voting-preparation) guide.
 
 The choice a ticket votes with depends on your vote preference at the time the ticket is chosen, not when it is bought. So you can set your choice at any time within the voting window and all future tickets will vote accordingly.
 

--- a/docs/governance/introduction-to-decred-governance.md
+++ b/docs/governance/introduction-to-decred-governance.md
@@ -14,7 +14,7 @@ In each block, five live tickets are selected pseudo-randomly and called to vote
 
 On-chain voting serves the following purposes:
 
-1. [Consensus rule voting](consensus-rules-voting.md) to *approve or reject a proposed change to the consensus rules* of the protocol. A proposed change must be approved by 75% of non-abstaining tickets to take effect.
+1. [Consensus rule voting](consensus-rule-voting/consensus-rules-voting.md) to *approve or reject a proposed change to the consensus rules* of the protocol. A proposed change must be approved by 75% of non-abstaining tickets to take effect.
 
 1. Voting to *approve the work of PoW Miners*. In order for a PoW Miner to receive their share of the block reward, at least three of the five tickets called in the subsequent block must approve their block. This gives ticket-holders power over PoW Miners in the case of undesirable behavior by miners (e.g. mining empty blocks), although this power is yet to be exercised on mainnet.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Subsidy | Party
 
 [Proof of Work](mining/proof-of-work.md) miners play a similar role for Decred as they do for Bitcoin, but with Decred they only receive 60% of the block reward.
 
-[Proof of Stake](proof-of-stake/proof-of-stake.md) voting is central to Decred's governance. Decred holders can time-lock (or "stake") DCR to obtain voting tickets. Tickets are randomly called to vote on-chain; this involves both approving the work of PoW miners and voting Yes/No on any open [rule change proposals](governance/consensus-rules-voting.md). 30% of the block reward goes to the holders of the tickets that voted in that block.
+[Proof of Stake](proof-of-stake/proof-of-stake.md) voting is central to Decred's governance. Decred holders can time-lock (or "stake") DCR to obtain voting tickets. Tickets are randomly called to vote on-chain; this involves both approving the work of PoW miners and voting Yes/No on any open [rule change proposals](governance/consensus-rule-voting/consensus-rules-voting.md). 30% of the block reward goes to the holders of the tickets that voted in that block.
 
 The remaining 10% of the block reward goes into the [Decred Treasury](https://explorer.dcrdata.org/address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx). Holders of live tickets decide how that treasury is used through [Politeia proposals and voting](governance/politeia/politeia.md).
 

--- a/docs/proof-of-stake/proof-of-stake.md
+++ b/docs/proof-of-stake/proof-of-stake.md
@@ -9,7 +9,7 @@ Proof-of-Stake (PoS) voting is a form of Proof-of-Stake (PoS) security, but the 
 
 PoS voting serves a number of purposes:
 
-1. Allowing stakeholders to vote for or against proposed changes to the Decred blockchain. If stakeholders vote in support of a change, the chain will hardfork and the new feature becomes active automatically. More information on voting can be found in the [Mainnet Voting Guide](../governance/consensus-rules-voting.md).
+1. Allowing stakeholders to vote for or against proposed changes to the Decred blockchain. If stakeholders vote in support of a change, the chain will hardfork and the new feature becomes active automatically. More information on voting can be found in the [Mainnet Voting Guide](../governance/consensus-rule-voting/consensus-rules-voting.md).
 1. Providing a mechanism for stakeholders to influence Proof-of-Work (PoW) miners. Stakeholders can vote to withhold a miner's reward even if the block conforms to the consensus rules of the network. This allows stakeholders, in principle, to discourage problematic mining behavior such as mining empty blocks.
 1. For a block to be valid, it has to be signed by at least 3 of the 5 tickets that are called to vote in that block. This makes the Decred blockchain more robust to certain kinds of attack, such as those which rely on secret mining.
 1. The same principle makes the Decred blockchain resistant to contentious hard forks. PoW Miners are unable to build on a chain without the Votes of the tickets that are called. 
@@ -63,7 +63,7 @@ A ticket on mainnet (testnet uses different parameters) will go through a few st
 
 ## Additional Information 
 
-[Mainnet Voting Guide](../governance/consensus-rules-voting.md)
+[Mainnet Voting Guide](../governance/consensus-rule-voting/consensus-rules-voting.md)
 
 [Proof-of-Stake FAQ - General](../faq/proof-of-stake/general.md)
 

--- a/httpd.conf
+++ b/httpd.conf
@@ -550,6 +550,7 @@ RedirectMatch "^/governance/governance/?$"                                  /gov
 RedirectMatch "^/governance/politeia/?$"                                    /governance/politeia/politeia
 RedirectMatch "^/getting-started/constitution/?$"                           /governance/decred-constitution
 RedirectMatch "^/getting-started/user-guides/agenda-voting/?$"              /governance/consensus-rules-voting
+RedirectMatch "^/governance/consensus-rules-voting/?$"                      /governance/consensus-rule-voting/consensus-rules-voting
 RedirectMatch "^/getting-started/user-guides/how-to-vote/?$"                /governance/how-to-vote
 RedirectMatch "^/getting-started/startup-basics/?$"                         /wallets/cli/startup-basics
 RedirectMatch "^/getting-started/cli-differences/?$"                        /wallets/cli/os-differences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,9 @@ nav:
     - 'Politeia': 'governance/politeia/politeia.md'
     - 'Proposal Guidelines': 'governance/politeia/proposal-guidelines.md'
     - 'Example Proposals': 'governance/politeia/example-proposals.md'
-  - 'Consensus Rules Voting': 'governance/consensus-rules-voting.md'
+  - Consensus Rule Voting:
+    - 'Consensus Rules Voting': 'governance/consensus-rule-voting/consensus-rules-voting.md'
+    - 'Consensus Vote Archive': 'governance/consensus-rule-voting/consensus-vote-archive.md'
   - 'How to Vote on Consensus Rule Changes': 'governance/how-to-vote.md'
   - 'Decred Constitution': 'governance/decred-constitution.md'
 - Wallets:


### PR DESCRIPTION
The single page for Consensus Rule Voting is getting rather long, and with another vote around the corner, it's about to get longer.

This PR moves the voting archive into its own page. No new copy or content is introduced here, just moving and refactoring things.

- Embed images using markdown syntax instead of html
- Use headers correctly in the archive