### PR TITLE
New question for FAQ for PoS voting

### DIFF
--- a/docs/faq/proof-of-stake/general.md
+++ b/docs/faq/proof-of-stake/general.md
@@ -169,6 +169,12 @@ This target was selected prior to Decred's launch to ensure that tickets would h
 
 ---
 
+#### 14. What happens if my Voting Service Provider (VSP) goes down?
+
+Voting rights are based on 1-of-2 multisig transactions. Therefore, in the unlikely event your Voting Service Provider (VSP) goes down permanently, you can still vote and receive your PoS reward, as well as revoke a missing or expired ticket. To do this, you will need to have a wallet with your VSPs pool script imported. See the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page for details on setting up a wallet for solo voting. 
+
+---
+
 ## :fa-book: Links
 
 [^1]: [Decrediton Ticket Purchasing Guide](../../wallets/decrediton/using-decrediton.md#tickets)

--- a/docs/faq/proof-of-stake/general.md
+++ b/docs/faq/proof-of-stake/general.md
@@ -167,11 +167,6 @@ Decred was specifically designed to minimise impact from both large PoW mining p
 
 This target was selected prior to Decred's launch to ensure that tickets would have a 99.5% chance of voting before they expire.
 
----
-
-#### 14. What happens if my Voting Service Provider (VSP) goes down?
-
-Voting rights are based on 1-of-2 multisig transactions. Therefore, in the unlikely event your Voting Service Provider (VSP) goes down permanently, you can still vote and receive your PoS reward, as well as revoke a missing or expired ticket. To do this, you will need to have a wallet with your VSPs pool script imported. See the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page for details on setting up a wallet for solo voting. 
 
 ---
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -57,7 +57,7 @@ Continue to [PoS Voting Tickets FAQ](voting-tickets.md)
 
 #### 8. What happens if my Voting Service Provider (VSP) goes down?
 
-If your VSP goes down, you can still vote your tickets, as well as revoke a missed or expired ticket. In this highly unlikely scenario, you can revoke your tickets in Decrediton, releasing the DCR used to purchase tickets back to your wallet. You can also vote and recieve the PoS reward if you have your VSP's pool script (available on the VSP's website). Voting rights are assigned to a 1-of-2 multisig address, where one of the required keys belongs to your wallet. Therefore, you can configure your wallet with your VSP's pool script imported, set it up for solo voting, and essentially become your own VSP. See the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page for details on setting up a wallet for solo voting. 
+In the unlikely scenario your VSP goes down permanently, you can still vote your tickets, as well as revoke a missed or expired ticket. Voting rights are assigned to a 1-of-2 multisig address, where one of the required keys belongs to your wallet. This allows you to configure a wallet with your VSP's pool script imported and set it up for solo voting, essentially becoming your own VSP. This will allow you to vote or revoke tickets. Note that the VSP's pool script is necessary to perform these actions. For this reason, it is important to always keep a backup of your VSP's pool script, which can be found on your VSPs webpage. For details on setting up a wallet for solo voting, see the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page.
 
 ---
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -55,6 +55,12 @@ Continue to [PoS Voting Tickets FAQ](voting-tickets.md)
 
 ---
 
+#### 8. What happens if my Voting Service Provider (VSP) goes down?
+
+If your VSP goes down, you can still vote your tickets, as well as revoke a missed or expired ticket. In this highly unlikely scenario, you can revoke your tickets in Decrediton, releasing the DCR used to purchase tickets back to your wallet. You can also vote and recieve the PoS reward if you have your VSP's pool script (available on the VSP's website). Voting rights are assigned to a 1-of-2 multisig address, where one of the required keys belongs to your wallet. Therefore, you can configure your wallet with your VSP's pool script imported, set it up for solo voting, and essentially become your own VSP. See the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page for details on setting up a wallet for solo voting. 
+
+---
+
 ## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources 
 
 [^9262]: Decred Forum, [Post 9,262](https://forum.decred.org/threads/626/#post-9262)


### PR DESCRIPTION
Adds a question to the PoS Voting General FAQ ( Closes #822 ).

#### 14. What happens if my Voting Service Provider (VSP) goes down?¶
Voting rights are based on 1-of-2 multisig transactions. Therefore, in the unlikely event your Voting Service Provider (VSP) goes down permanently, you can still vote and receive your PoS reward, as well as revoke a missing or expired ticket. To do this, you will need to have a wallet with your VSPs pool script imported. See the [Solo Proof-of-Stake (PoS) Voting](../../advanced/solo-proof-of-stake-voting.md) page for details on setting up a wallet for solo voting.