### PR TITLE
Reorganizes FAQs, renames 'What is Proof-of-Stake?' page 

### DIFF
--- a/docs/faq/errors.md
+++ b/docs/faq/errors.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Question.svg" /> Common Errors and Solutions
 
-## Proof-of-Stake 
+## Proof-of-Stake (PoS)
 
 #### 1. Some of my missed/expired tickets are still locked after more than a day. 
 

--- a/docs/faq/proof-of-work-mining.md
+++ b/docs/faq/proof-of-work-mining.md
@@ -1,4 +1,4 @@
-# :fa-fire: Proof-of-work Mining
+# :fa-fire: Proof-of-Work (PoW) Mining
 
 ---
 

--- a/docs/proof-of-stake/proof-of-stake.md
+++ b/docs/proof-of-stake/proof-of-stake.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Proof of Stake Voting
+# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Proof-of-Stake (PoS) Voting
 
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,14 +81,8 @@ nav:
       - 'dcrctl RPC Commands': 'wallets/cli/dcrctl-rpc-commands.md'
     - 'SPV': 'wallets/spv.md'
 - Proof-of-Stake Voting:
-  - "What is Proof-of-Stake?": 'proof-of-stake/proof-of-stake.md'
+  - "Overview": 'proof-of-stake/proof-of-stake.md'
   - "How to Stake": 'proof-of-stake/how-to-stake.md' 
-  - PoS FAQ:
-    - 'General': 'faq/proof-of-stake/general.md'
-    - 'Solo Voting': 'faq/proof-of-stake/solo-voting.md'
-    - 'Buying Tickets and Fees': 'faq/proof-of-stake/buying-tickets-and-fees.md'
-    - 'Voting Tickets': 'faq/proof-of-stake/voting-tickets.md'
-    - 'Voting Service Providers': 'faq/proof-of-stake/voting-service-providers.md'
 - Proof-of-Work Mining:
   - 'Overview': 'mining/proof-of-work.md'
   - 'gominer Pool Mining': 'mining/proof-of-work/pool-mining/gominer.md'
@@ -99,6 +93,13 @@ nav:
   - 'Wallets and Seeds': 'faq/wallets-and-seeds.md'
   - 'Blocks': 'faq/blocks.md'
   - 'Common Errors and Solutions': 'faq/errors.md'
+  - 'PoW': 'faq/proof-of-work-mining.md'
+  - PoS:
+    - 'General': 'faq/proof-of-stake/general.md'
+    - 'Solo Mining': 'faq/proof-of-stake/solo-mining.md'
+    - 'Buying Tickets and Fees': 'faq/proof-of-stake/buying-tickets-and-fees.md'
+    - 'Voting Tickets': 'faq/proof-of-stake/voting-tickets.md'
+    - 'Voting Service Providers': 'faq/proof-of-stake/voting-service-providers.md'
 - Advanced:
   - 'Address Details': advanced/address-details.md
   - 'Using Testnet': 'advanced/using-testnet.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,7 @@ nav:
   - 'PoW': 'faq/proof-of-work-mining.md'
   - PoS:
     - 'General': 'faq/proof-of-stake/general.md'
-    - 'Solo Mining': 'faq/proof-of-stake/solo-mining.md'
+    - 'Solo Voting': 'faq/proof-of-stake/solo-voting.md'
     - 'Buying Tickets and Fees': 'faq/proof-of-stake/buying-tickets-and-fees.md'
     - 'Voting Tickets': 'faq/proof-of-stake/voting-tickets.md'
     - 'Voting Service Providers': 'faq/proof-of-stake/voting-service-providers.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,6 @@ nav:
 - Proof-of-Work Mining:
   - 'Overview': 'mining/proof-of-work.md'
   - 'gominer Pool Mining': 'mining/proof-of-work/pool-mining/gominer.md'
-  - 'PoW FAQ': 'faq/proof-of-work-mining.md'
 - FAQ:
   - 'General': 'faq/general.md'
   - 'Configuration': 'faq/configuration.md'


### PR DESCRIPTION
Moves the PoS FAQ pages to under the top-level FAQ menu ( Closes #833 ). 

Renames the 'What is Proof-of-Stake?' page to 'Overview', as discussed [here](https://github.com/decred/dcrdocs/issues/814), making it consistent with the PoW 'Overview' page.

Also, while I was here, did some minor cleanup around naming consistency. Just changing instances of 'Proof of Stake/Work' with 'Proof-of-Stake (PoS'), Proof-of-Work (PoW), to make them consistent with other pages in the docs. 

@jholdstock , realize I'm bundling together a few small issues here. Can break into separate PRs if you think that's better.