### PR TITLE
Move How to Vote under Consensus Rule Changes

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -63,4 +63,5 @@ server {
     rewrite ^/mining/proof-of-stake/?$                                  $scheme://$http_host/proof-of-stake/proof-of-stake permanent;
     rewrite ^/mining/how-to-stake/?$                                    $scheme://$http_host/proof-of-stake/how-to-stake permanent;
     rewrite ^/faq/proof-of-stake/solo-mining/?$                         $scheme://$http_host/faq/proof-of-stake/solo-voting permanent;
+    rewrite ^/governance/how-to-vote/?$                                 $scheme://$http_host/governance/consensus-rule-voting/how-to-vote permanent;
 }

--- a/docs/governance/consensus-rule-voting/consensus-rules-voting.md
+++ b/docs/governance/consensus-rule-voting/consensus-rules-voting.md
@@ -37,7 +37,7 @@ To participate in voting, you first need a wallet. If you don't have one already
 
 Next, you'll need to learn the basics of [Proof-of-Stake](../../proof-of-stake/proof-of-stake.md). You'll need to be able to [buy tickets](../../proof-of-stake/how-to-stake.md) with your application of choice.
 
-Finally, you'll need to learn how to set the `votechoice` for your tickets in order to cast a "Yes", "No", or "Abstain" vote for an agenda. By default, your tickets will cast "Abstain" votes. To set your vote choice, see our quick [How To Vote](../how-to-vote.md).
+Finally, you'll need to learn how to set the `votechoice` for your tickets in order to cast a "Yes", "No", or "Abstain" vote for an agenda. By default, your tickets will cast "Abstain" votes. To set your vote choice, see our quick [How To Vote](how-to-vote.md).
 
 ---
 

--- a/docs/governance/consensus-rule-voting/how-to-vote.md
+++ b/docs/governance/consensus-rule-voting/how-to-vote.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> **How to Vote on consensus rule changes**
+# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> **How to Vote**
 
 This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](consensus-rule-voting/consensus-rules-voting.md#voting-preparation) guide.
 

--- a/docs/governance/consensus-rule-voting/how-to-vote.md
+++ b/docs/governance/consensus-rule-voting/how-to-vote.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> **How to Vote**
 
-This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](consensus-rule-voting/consensus-rules-voting.md#voting-preparation) guide.
+This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](consensus-rules-voting.md#voting-preparation) guide.
 
 The choice a ticket votes with depends on your vote preference at the time the ticket is chosen, not when it is bought. So you can set your choice at any time within the voting window and all future tickets will vote accordingly.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,8 +61,8 @@ nav:
     - 'Example Proposals': 'governance/politeia/example-proposals.md'
   - Consensus Rule Voting:
     - 'Consensus Rules Voting': 'governance/consensus-rule-voting/consensus-rules-voting.md'
+    - 'How to Vote': 'governance/consensus-rule-voting/how-to-vote.md'
     - 'Consensus Vote Archive': 'governance/consensus-rule-voting/consensus-vote-archive.md'
-  - 'How to Vote on Consensus Rule Changes': 'governance/how-to-vote.md'
   - 'Decred Constitution': 'governance/decred-constitution.md'
 - Wallets:
     - Decrediton (GUI):


### PR DESCRIPTION
Moves the 'How to Vote under Consensus Rule Changes' page under the 'Consensus Rule Voting' menu ( Closes #839 ). Also, as it's clear from the menu now what is being voted on, have renamed 'How to Vote under Consensus Rule Changes' to 'How to Vote'.

Menu now looks like this:
![image](https://user-images.githubusercontent.com/1634777/52503424-6458a600-2b9a-11e9-98b1-1d1966d9c0f6.png)
