### PR TITLE
Restores search plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ extra_css:
   - css/style.css
 plugins:
   - markdownextradata
+  - search
 nav:
 - 'Home': 'index.md'
 - Getting Started:


### PR DESCRIPTION
It appears search disappeared when we added template variables in PR https://github.com/decred/dcrdocs/pull/645. This happened because previously, search was enabled by default in MkDocs. So when we added our first plugin to `mkdocs.yml`, the default was overwritten, removing search. This PR fixes this by explicitly adding it back ( Closes #845 ). 