### PR TITLE
Add list of testnet VSPs to testnet page

### DIFF
--- a/docs/advanced/using-testnet.md
+++ b/docs/advanced/using-testnet.md
@@ -42,11 +42,9 @@ You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.
 
 ---
 
-## Voting Service Providers (VSP)
+## Testnet Voting Service Providers (VSP)
 
 To experiment with staking and voting with a Voting Service Provider (VSP), you'll need to sign up for a testnet VSP. 
-
-### Testnet VSPs
 
 - [https://testnet.decredvoting.com](https://testnet.decredvoting.com)
 - [https://test-dcrpool.dittrex.com](https://test-dcrpool.dittrex.com)

--- a/docs/advanced/using-testnet.md
+++ b/docs/advanced/using-testnet.md
@@ -39,3 +39,16 @@ To issue commands to both `dcrwallet` and `dcrd`, you must also add the `--testn
 ## Acquiring Testnet Coins
 
 You can acquire coins through the [Decred Testnet Faucet](https://faucet.decred.org). Please return any coins to the address listed at the bottom of that page when you're done playing with the testnet.
+
+---
+
+## Voting Service Providers (VSP)
+
+To experiment with staking and voting with a Voting Service Provider (VSP), you'll need to sign up for a testnet VSP. 
+
+### Testnet VSPs
+
+- [https://testnet.decredvoting.com](https://testnet.decredvoting.com)
+- [https://test-dcrpool.dittrex.com](https://test-dcrpool.dittrex.com)
+- [https://teststakepool.decred.org](https://teststakepool.decred.org)
+- [https://test.stakey.net](https://test.stakey.net)


### PR DESCRIPTION
This PR adds a list testnet VSPs to the testnet page, along with a sentence explaining why one would need a testnet VSP ( Closes #855 ).