### PR TITLE
Refine use of variables.

### DIFF
--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -1,10 +1,10 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> Manual CLI Installation
 
-Last updated for CLI release v1.2.0.
+Last updated for CLI release v{{ cliversion }}.
 
 ---
 
-The newest binary releases can be found [here](https://github.com/decred/decred-binaries/releases). With the exception of the `.exe` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be extract and go, instructions are provided for Windows, macOS, and Linux below (assumed proficiency for FreeBSD users).
+The newest binary releases can be found [here](https://github.com/decred/decred-binaries/releases). With the exception of the `.exe` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be extract and go, instructions are provided for Windows, macOS, and Linux below.
 
 ??? info "Windows instructions (click to expand)"
 
@@ -14,10 +14,10 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
     1. Download the correct file for your computer:
 
-        | Architecture | Filename                          |
-        | ------------ | ----------------------------------|
-        | 32-bit       | `decred-windows-386-v{{ cliversion.windows }}.zip`   |
-        | 64-bit       | `decred-windows-amd64-v{{ cliversion.windows }}.zip` |
+        | Architecture | Filename                                     |
+        | ------------ | ---------------------------------------------|
+        | 32-bit       | `decred-windows-386-v{{ cliversion }}.zip`   |
+        | 64-bit       | `decred-windows-amd64-v{{ cliversion }}.zip` |
 
     1. Navigate to download location and extract the `.zip` file:
 
@@ -27,16 +27,17 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
     1. Download the correct file for your computer:
 
-        | Architecture | Filename                            |
-        | ------------ | ----------------------------------- |
-        | 64-bit       | `decred-darwin-amd64-v{{ cliversion.mac }}.tar.gz` |
+        | Architecture | Filename                                       |
+        | ------------ | ---------------------------------------------- |
+        | 64-bit       | `decred-darwin-amd64-v{{ cliversion }}.tar.gz` |
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
         **Finder:** simply double click on the `.tar.gz` file.
+
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion.mac }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion.mac }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
 
     !!! note
 
@@ -46,12 +47,12 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
     1. Download the correct file for your computer:
 
-        | Architecture | Filename                           |
-        | ------------ | ---------------------------------- |
-        | 32-bit       | `decred-linux-386-v{{ cliversion.linux }}.tar.gz`   |
-        | 64-bit       | `decred-linux-amd64-v{{ cliversion.linux }}.tar.gz` |
-        | 32-bit ARM   | `decred-linux-arm-v{{ cliversion.linux }}.tar.gz`   |
-        | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion.linux }}.tar.gz` |
+        | Architecture | Filename                                      |
+        | ------------ | --------------------------------------------- |
+        | 32-bit       | `decred-linux-386-v{{ cliversion }}.tar.gz`   |
+        | 64-bit       | `decred-linux-amd64-v{{ cliversion }}.tar.gz` |
+        | 32-bit ARM   | `decred-linux-arm-v{{ cliversion }}.tar.gz`   |
+        | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion }}.tar.gz` |
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
@@ -59,7 +60,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion.linux }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion.linux }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
 
 ---
 

--- a/docs/advanced/solo-proof-of-stake-voting.md
+++ b/docs/advanced/solo-proof-of-stake-voting.md
@@ -1,6 +1,6 @@
 # Solo Proof-of-Stake (PoS) Voting
 
-Last updated for CLI release v1.4.0.
+Last updated for CLI release v{{ cliversion }}.
 
 ---
 
@@ -38,25 +38,25 @@ Once your machine is set up you will need to install the Decred CLI tools.
 
 1. Download the installer, manifest, and signature files.
 
-    `wget https://github.com/decred/decred-release/releases/download/v1.4.0/{dcrinstall-linux-amd64-v1.4.0,manifest-dcrinstall-v1.4.0.txt,manifest-dcrinstall-v1.4.0.txt.asc}`
+    `wget https://github.com/decred/decred-release/releases/download/v{{ cliversion }}/{dcrinstall-linux-amd64-v{{ cliversion }},manifest-dcrinstall-v{{ cliversion }}.txt,manifest-dcrinstall-v{{ cliversion }}.txt.asc}`
 
 1. Verify the manifest. The output from this command should say "Good signature from Decred Release <release@decred.org>". Warnings about the key not being certified with a trusted signature can be ignored.
 
-    `gpg --verify manifest-dcrinstall-v1.4.0.txt.asc`
+    `gpg --verify manifest-dcrinstall-v{{ cliversion }}.txt.asc`
 
 1. Verify the SHA-256 hash in the manifest matches that of the binary - the following two commands should have the same output.
 
-    `sha256sum dcrinstall-linux-amd64-v1.4.0`
+    `sha256sum dcrinstall-linux-amd64-v{{ cliversion }}`
 
-    `grep dcrinstall-linux-amd64-v1.4.0 manifest-dcrinstall-v1.4.0.txt`
+    `grep dcrinstall-linux-amd64-v{{ cliversion }} manifest-dcrinstall-v{{ cliversion }}.txt`
 
 1. Make the binary executable.
 
-    `chmod +x dcrinstall-linux-amd64-v1.4.0`
+    `chmod +x dcrinstall-linux-amd64-v{{ cliversion }}`
 
 1. Run it to install the Decred CLI tools and to create your wallet.
 
-    `./dcrinstall-linux-amd64-v1.4.0`
+    `./dcrinstall-linux-amd64-v{{ cliversion }}`
 
 1. Add the path to the Decred binaries to your `.profile`.
 
@@ -116,23 +116,23 @@ Setting vote choices for on-chain votes will happen on the remote servers you wi
 
 1. Download the Politeia archive, manifest, and signature files.
 
-    `wget https://github.com/decred/decred-binaries/releases/download/v{{ pivoterversion.linux }}/{politeiavoter-linux-amd64-v{{ pivoterversion.linux }}.tar.gz,manifest-politeiavoter-v{{ pivoterversion.linux }}.txt,manifest-politeiavoter-v{{ pivoterversion.linux }}.txt.asc}`
+    `wget https://github.com/decred/decred-binaries/releases/download/v{{ pivoterversion }}/{politeiavoter-linux-amd64-v{{ pivoterversion }}.tar.gz,manifest-politeiavoter-v{{ pivoterversion }}.txt,manifest-politeiavoter-v{{ pivoterversion }}.txt.asc}`
 
 1. Verify the manifest. The output from this command should say "Good signature from Decred Release <release@decred.org>". Warnings about the key not being certified with a trusted signature can be ignored.
 
-    `gpg --verify manifest-politeiavoter-v{{ pivoterversion.linux }}.txt.asc`
+    `gpg --verify manifest-politeiavoter-v{{ pivoterversion }}.txt.asc`
 
 1. Verify the SHA-256 hash in the manifest matches that of the archive - the following two commands should have the same output.
 
-    `sha256sum politeiavoter-linux-amd64-v{{ pivoterversion.linux }}.tar.gz`
+    `sha256sum politeiavoter-linux-amd64-v{{ pivoterversion }}.tar.gz`
 
-    `grep politeiavoter-linux-amd64-v{{ pivoterversion.linux }}.tar.gz manifest-politeiavoter-v{{ pivoterversion.linux }}.txt`
+    `grep politeiavoter-linux-amd64-v{{ pivoterversion }}.tar.gz manifest-politeiavoter-v{{ pivoterversion }}.txt`
 
 1. Extract the archive.
 
-    `tar -xf politeiavoter-linux-amd64-v{{ pivoterversion.linux }}.tar.gz`
+    `tar -xf politeiavoter-linux-amd64-v{{ pivoterversion }}.tar.gz`
 
-1. Enter the `politeiavoter-linux-amd64-v{{ pivoterversion.linux }}` directory.
+1. Enter the `politeiavoter-linux-amd64-v{{ pivoterversion }}` directory.
 
 Now to view the various agendas and vote on them you will need to run the following commands. Also remember that for this to work `dcrd` and `dcrwallet` must also be running.
 
@@ -170,7 +170,7 @@ sudo apt update;
 sudo apt upgrade;
 sudo apt install tmux curl;
 
-v=v1.4.0;
+v=v{{ cliversion }};
 a=amd64;
 b=dcrinstall-linux-${a}-${v};
 wget https://github.com/decred/decred-release/releases/download/${v}/${b};
@@ -183,7 +183,7 @@ echo "PATH=~/decred:$PATH" >> ~/.profile;
 source ~/.profile
 ```
 
-You may want to change the `v=v1.4.0` to the latest version if a newer one has been released and `a=amd64` to whatever CPU architecture your VPS is using.
+You may want to change the `v=v{{ cliversion }}` to the latest version if a newer one has been released and `a=amd64` to whatever CPU architecture your VPS is using.
 
 Start everything: `./decred.sh`
 

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> CLI Installation guide
 
-Last updated for CLI release v{{ cliversion.mac }}.
+Last updated for CLI release v{{ cliversion }}.
 
 ---
 
@@ -12,17 +12,17 @@ Last updated for CLI release v{{ cliversion.mac }}.
 
 ??? info "macOS instructions (click to expand)"
 
-    1. Download the `dcrinstall-darwin-amd64-v{{ cliversion.mac }}` file. (32 bit builds for macOS are not available):
+    1. Download the `dcrinstall-darwin-amd64-v{{ cliversion }}` file. (32 bit builds for macOS are not available):
 
-    1. Make `dcrinstall-darwin-amd64-v{{ cliversion.mac }}` an executable within your terminal, and run it:
+    1. Make `dcrinstall-darwin-amd64-v{{ cliversion }}` an executable within your terminal, and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run `chmod` with `u+x` mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
 
         `cd ~/Downloads/`
 
-        `chmod u+x dcrinstall-darwin-amd64-v{{ cliversion.mac }}`
+        `chmod u+x dcrinstall-darwin-amd64-v{{ cliversion }}`
 
-        `./dcrinstall-darwin-amd64-v{{ cliversion.mac }}`
+        `./dcrinstall-darwin-amd64-v{{ cliversion }}`
 
     1. The executable binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
@@ -30,13 +30,13 @@ Last updated for CLI release v{{ cliversion.mac }}.
 
     1. Download the correct file:
 
-        For 32-bit computers, download the `dcrinstall-linux-386-v{{ cliversion.linux }}` file.
+        For 32-bit computers, download the `dcrinstall-linux-386-v{{ cliversion }}` file.
 
-        For 64-bit computers, download the `dcrinstall-linux-amd64-v{{ cliversion.linux }}` file.
+        For 64-bit computers, download the `dcrinstall-linux-amd64-v{{ cliversion }}` file.
 
-        For 32-bit ARM computers, download the `dcrinstall-linux-arm-v{{ cliversion.linux }}` file.
+        For 32-bit ARM computers, download the `dcrinstall-linux-arm-v{{ cliversion }}` file.
 
-        For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion.linux }}` file.
+        For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion }}` file.
 
     1. Make the downloaded file an executable within your terminal and run it:
 
@@ -44,9 +44,9 @@ Last updated for CLI release v{{ cliversion.mac }}.
 
         `cd ~/Downloads/`
 
-        `chmod u+x dcrinstall-linux-amd64-v{{ cliversion.linux }}`
+        `chmod u+x dcrinstall-linux-amd64-v{{ cliversion }}`
 
-        `./dcrinstall-linux-amd64-v{{ cliversion.linux }}`
+        `./dcrinstall-linux-amd64-v{{ cliversion }}`
 
     1. The binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
@@ -54,9 +54,9 @@ Last updated for CLI release v{{ cliversion.mac }}.
 
     1. Download the correct file:
 
-        For 32-bit computers, download the `dcrinstall-windows-386-v{{ cliversion.windows }}.exe` file.
+        For 32-bit computers, download the `dcrinstall-windows-386-v{{ cliversion }}.exe` file.
 
-        For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion.windows }}.exe` file.
+        For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion }}.exe` file.
 
 
     1. Run the dcrinstall executable file. You can either double click it or run it from the Command Prompt.

--- a/docs/wallets/cli/dcrctl-rpc-commands.md
+++ b/docs/wallets/cli/dcrctl-rpc-commands.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> `dcrctl` RPC Commands
 
-Last updated for CLI release v{{ cliversion.mac }}.
+Last updated for CLI release v{{ cliversion }}.
 
 ---
 
@@ -26,53 +26,53 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `existsmissedtickets`     | `"txhashblob"`
     `generate`                | `numblocks`
     `getaddednodeinfo`        | `dns` (`"node"`)
-    `getbestblock`            | 
-    `getbestblockhash`        | 
+    `getbestblock`            |
+    `getbestblockhash`        |
     `getblock`                | `"hash"` (`verbose=true` `verbosetx=false`)
-    `getblockchaininfo`       | 
-    `getblockcount`           | 
+    `getblockchaininfo`       |
+    `getblockcount`           |
     `getblockhash`            | `index`
     `getblockheader`          | `"hash"` (`verbose=true`)
     `getblocksubsidy`         | `height` `voters`
     `getblocktemplate`        | (`{"mode":"value", "capabilities":["capability",...], "longpollid":"value", "sigoplimit":sigoplimit, "sizelimit":sizelimit, "maxversion":n, "target":"value", "data":"value", "workid":"value"}`)
     `getcfilter`              | `"hash"` `"filtertype"`
     `getcfilterheader`        | `"hash"` `"filtertype"`
-    `getchaintips`            | 
-    `getcoinsupply`           | 
-    `getconnectioncount`      | 
-    `getcurrentnet`           | 
-    `getdifficulty`           | 
-    `getgenerate`             | 
-    `gethashespersec`         | 
+    `getchaintips`            |
+    `getcoinsupply`           |
+    `getconnectioncount`      |
+    `getcurrentnet`           |
+    `getdifficulty`           |
+    `getgenerate`             |
+    `gethashespersec`         |
     `getheaders`              | `"blocklocators"` `"hashstop"`
-    `getinfo`                 | 
-    `getmempoolinfo`          | 
-    `getmininginfo`           | 
-    `getnettotals`            | 
+    `getinfo`                 |
+    `getmempoolinfo`          |
+    `getmininginfo`           |
+    `getnettotals`            |
     `getnetworkhashps`        | (`blocks=120` `height=-1`)
-    `getnetworkinfo`          | 
-    `getpeerinfo`             | 
+    `getnetworkinfo`          |
+    `getpeerinfo`             |
     `getrawmempool`           | (`verbose=false` `"txtype"`)
     `getrawtransaction`       | `"txid"` (`verbose=0`)
-    `getstakedifficulty`      | 
+    `getstakedifficulty`      |
     `getstakeversioninfo`     | (`count`)
     `getstakeversions`        | `"hash"` `count`
-    `getticketpoolvalue`      | 
+    `getticketpoolvalue`      |
     `gettxout`                | `"txid"` `vout` (`includemempool=true`)
-    `gettxoutsetinfo`         | 
+    `gettxoutsetinfo`         |
     `getvoteinfo`             | `version`
     `getwork`                 | (`"data"`)
     `help`                    | (`"command"`)
-    `livetickets`             | 
-    `missedtickets`           | 
+    `livetickets`             |
+    `missedtickets`           |
     `node`                    | `"connect|remove|disconnect"` `"target"` (`"perm|temp"`)
-    `ping`                    | 
-    `rebroadcastmissed`       | 
-    `rebroadcastwinners`      | 
+    `ping`                    |
+    `rebroadcastmissed`       |
+    `rebroadcastwinners`      |
     `searchrawtransactions`   | `"address"` (`verbose=1` `skip=0` `count=100` `vinextra=0` `reverse=false` `["filteraddr",...]`)
     `sendrawtransaction`      | `"hextx"` (`allowhighfees=false`)
     `setgenerate`             | `generate` (`genproclimit=-1`)
-    `stop`                    | 
+    `stop`                    |
     `submitblock`             | `"hexblock"` (`{"workid":"value"}`)
     `ticketfeeinfo`           | (`blocks` `windows`)
     `ticketsforaddress`       | `"address"`
@@ -81,7 +81,7 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `validateaddress`         | `"address"`
     `verifychain`             | (`checklevel=3` `checkdepth=288`)
     `verifymessage`           | `"address"` `"signature"` `"message"`
-    `version`                 | 
+    `version`                 |
 
 ---
 
@@ -99,8 +99,7 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `createnewaccount`        | `"account"`
     `createrawssgentx`        | `[{"amount":n.nnn,"txid":"value","vout":n,"tree":n},...]` `votebits`
     `createrawssrtx`          | `[{"amount":n.nnn,"txid":"value","vout":n,"tree":n},...]` (`fee`)
-    `createrawsstx`           | `[{"txid":"value", "vout":n, "tree":n, "amt":n},...]` `amount` `[{"addr":"value", "commitamt":n, 
-    "changeaddr":"value", "changeamt":n},...]`
+    `createrawsstx`           | `[{"txid":"value", "vout":n, "tree":n, "amt":n},...]` `amount` `[{"addr":"value", "commitamt":n, "changeaddr":"value", "changeamt":n},...]`
     `createvotingaccount`     | `"name"` `"pubkey"` (`childindex=0`)
     `dropvotingaccount`       |
     `dumpprivkey`             | `"address"`
@@ -119,22 +118,22 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `getrawchangeaddress`     | (`"account"`)
     `getreceivedbyaccount`    | `"account"` (`minconf=1`)
     `getreceivedbyaddress`    | `"address"` (`minconf=1`)
-    `getstakeinfo`            | 
-    `getticketfee`            | 
+    `getstakeinfo`            |
+    `getticketfee`            |
     `gettickets`              | `includeimmature`
     `gettransaction`          | `"txid"` (`includewatchonly=false`)
-    `getvotechoices`          | 
-    `getwalletfee`            | 
+    `getvotechoices`          |
+    `getwalletfee`            |
     `importprivkey`           | `"privkey"` (`"label"` `rescan=true` `scanfrom`)
     `importscript`            | `"hex"` (`rescan=true` `scanfrom`)
     `keypoolrefill`           | (`newsize=100`)
     `listaccounts`            | (`minconf=1`)
-    `listlockunspent`         | 
+    `listlockunspent`         |
     `listreceivedbyaccount`   | (`minconf=1` `includeempty=false` `includewatchonly=false`)
     `listreceivedbyaddress`   | (`minconf=1` `includeempty=false` `includewatchonly=false`)
-    `listscripts`             | 
+    `listscripts`             |
     `listsinceblock`          | (`"blockhash"` `targetconfirmations=1` `includewatchonly=false`)
-    `listtickets`             | 
+    `listtickets`             |
     `listtransactions`        | (`"account"` `count=10` `from=0` `includewatchonly=false`)
     `listunspent`             | (`minconf=1` `maxconf=9999999` `["address",...]`)
     `lockunspent`             | `unlock` `[{"amount":n.nnn,"txid":"value","vout":n,"tree":n},...]`
@@ -143,7 +142,7 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `redeemmultisigouts`      | `"fromscraddress"` (`"toaddress"` `number`)
     `renameaccount`           | `"oldaccount"` `"newaccount"`
     `rescanwallet`            | (`beginheight=0`)
-    `revoketickets`           | 
+    `revoketickets`           |
     `sendfrom`                | `"fromaccount"` `"toaddress"` `amount` (`minconf=1` `"comment"` `"commentto"`)
     `sendmany`                | `"fromaccount"` `{"address":amount,...}` (`minconf=1` `"comment"`)
     `sendtoaddress`           | `"address"` `amount` (`"comment"` `"commentto"`)
@@ -156,10 +155,10 @@ Last updated for CLI release v{{ cliversion.mac }}.
     `signrawtransactions`     | `["rawtx",...]` (`send=true`)
     `stakepooluserinfo`       | `"user"`
     `startautobuyer`          | `"account"` `"passphrase"` (`balancetomaintain` `maxfeeperkb` `maxpricerelative` `maxpriceabsolute` `"votingaddress"` `"pooladdress"` `poolfees` `maxperblock`)
-    `stopautobuyer`           | 
+    `stopautobuyer`           |
     `sweepaccount`            | `"sourceaccount"` `"destinationaddress"` (`requiredconfirmations` `feeperkb`)
     `verifyseed`              | `"seed"` (`account`)
-    `walletinfo`              | 
-    `walletlock`              | 
+    `walletinfo`              |
+    `walletlock`              |
     `walletpassphrase`        | `"passphrase"` `timeout`
     `walletpassphrasechange`  | `"oldpassphrase"` `"newpassphrase"`

--- a/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
+++ b/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Options2.svg" /> `dcrd` and `dcrwallet` CLI Arguments
 
-Last updated for CLI release v{{ cliversion.mac }}.
+Last updated for CLI release v{{ cliversion }}.
 
 ---
 Both the `dcrd` and `dcrwallet` daemons should work with default configuration for most users, however there is a wide variety of command line arguments to change the way they behave if required. For example, the following command can be used to change the log directory `dcrd` will write to.

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Decrediton Setup Guide
 
-Last updated for Decrediton v{{ decreditonversion.windows }}.
+Last updated for Decrediton v{{ decreditonversion }}.
 
 ---
 
@@ -18,7 +18,7 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
 ??? info "Windows instructions (click to expand)"
 
-    1. Download the Windows installer `decrediton-v{{ decreditonversion.windows }}.exe`.
+    1. Download the Windows installer `decrediton-v{{ decreditonversion }}.exe`.
 
     1. Double click the installer and follow the instructions.
 
@@ -26,17 +26,17 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
 ??? info "macOS instructions (click to expand)"
 
-    1. Download the `decrediton-v{{ decreditonversion.mac }}.dmg` file.
+    1. Download the `decrediton-v{{ decreditonversion }}.dmg` file.
 
-    1. Double click the `decrediton-v{{ decreditonversion.mac }}.dmg` file to mount the disk image.
+    1. Double click the `decrediton-v{{ decreditonversion }}.dmg` file to mount the disk image.
 
     1. Drag the `decrediton.app` file into the link to your Applications folder within the disk image.
 
 ??? info "Linux instructions (click to expand)"
 
-    1. Download the `decrediton-v{{ decreditonversion.mac }}.tar.gz` file.
+    1. Download the `decrediton-v{{ decreditonversion }}.tar.gz` file.
 
-    1. Navigate to the download location and extract `decrediton-v{{ decreditonversion.mac }}.tar.gz`.
+    1. Navigate to the download location and extract `decrediton-v{{ decreditonversion }}.tar.gz`.
 
     1. The extracted files include an executable named `decrediton`.
 

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -1,6 +1,6 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Using Decrediton
 
-Last updated for Decrediton v{{ decreditonversion.windows }}.
+Last updated for Decrediton v{{ decreditonversion }}.
 
 This guide assumes you have already set up a Decrediton wallet using [the Decrediton Setup guide](decrediton-setup.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,18 +129,9 @@ nav:
 - 'Glossary': 'glossary.md'
 copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new"><i class="fa fa-github"></i> open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare"><i class="fa fa-github"></i> send a pull request</a>.<br>dcrdocs v0.0.3. Decred Project 2019.
 extra:
-  decreditonversion:
-    windows: 1.4.0
-    linux: 1.4.0
-    mac: 1.4.0
-  cliversion:
-    windows: 1.4.0
-    linux: 1.4.0
-    mac: 1.4.0
-  pivoterversion:
-    windows: 1.4.0
-    linux: 1.4.0
-    mac: 1.4.0
+  decreditonversion: 1.4.0
+  cliversion: 1.4.0
+  pivoterversion: 1.4.0
   gominerversion: 1.0.0
   seedWarning1:
     "During the creation process for your wallet, you will be given a sequence of 33 words known as a seed phrase. This seed phrase is essentially the private key for your wallet. You will be able to use this seed phrase to restore your private keys, transaction history, and balances using any Decred wallet on any computer."


### PR DESCRIPTION
There is no precedent for release versions being different per operating system, so this PR consolidates the win/mac/linux variables into one. Also makes use of `cliversion` variable in the solo PoS guide. 