### PR TITLE
Proposal guidelines: advice to mind target audience

### DIFF
--- a/docs/governance/politeia/example-proposals.md
+++ b/docs/governance/politeia/example-proposals.md
@@ -23,7 +23,7 @@ be addressed.
 In the *Why* section, answer why the proposal is needed and why it is
 a good idea.
 
-> Currently there is no prescribed way to remotely determine if politeiawww is functioning correctly. We propose to add a single RPC that doubles as the heartbeat and a status monitor.
+> Currently there is no prescribed way to remotely determine if politeiawww is functioning correctly. This is problematic because if there is a problem with politeiawww, the Politeia website could experience outages and Decred admins would not be aware of it until users were negatively impacted. We propose to add a single RPC that doubles as the heartbeat and a status monitor.
 > The idea is that monitoring software can periodically issue the RPC and determine if an alert needs to be sent out to the admins.
 
 ### How

--- a/docs/governance/politeia/proposal-guidelines.md
+++ b/docs/governance/politeia/proposal-guidelines.md
@@ -62,6 +62,14 @@ blockchain space. Over-hyped, buzzword-filled proposals without substance will l
 ignored. Be precise in your use of technical terms, realistic in your projections, 
 and bring your A game in the comments.
 
+#### Speak to a broad audience
+
+Some proposals will necessarily contain complex concepts and jargon. This is fine.
+Be aware however that not all stakeholders will be experts in your domain. You'll need 
+their votes too. Take part of your proposal to explain any complex ideas in simple,
+easy-to-understand language all stakeholders can understand. 
+
+
 #### Build Credibility
 
 The bigger the proposal, the more you will need to convince stakeholders you 


### PR DESCRIPTION
Adds tip to the proposal guidelines page that reminds proposers to explain complex concepts and jargon in a way all stakeholders can understand ( Closes #876 ). Also updates the example software proposal to adhere to this tip. 