### PR TITLE
Overhaul consensus voting overview.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -3,6 +3,7 @@
 ---
 
 ## A
+
 ---
 
 #### Account
@@ -13,7 +14,6 @@ Accounts allow you to keep separate records of your DCR funds. Transferring DCR 
 
 A human-readable representation of a possible destination for a payment, similar to an email address. Unlike an email address however, there are a variety of address types, and most addresses are intended only for a single use. This is because addresses represent not only the destination of a payment, but constraints required to redeem funds. For more on addresses see the [address details](advanced/address-details.md) page.  
 
-
 #### ASIC
 
 An Application-Specific-Integrated-Circuit (ASIC) is a computing device which has been designed to perform only a single task with extreme efficiency. In the context of cryptocurrency, an ASIC is usually designed to perform Proof-of-Work (PoW) mining. Hashrates from ASICs are typically orders of magnitudes higher than hashrates from general purpose CPUs or GPUs.
@@ -21,7 +21,6 @@ An Application-Specific-Integrated-Circuit (ASIC) is a computing device which ha
 #### Atom
 
 The smallest unit of Decred currency. One atom is one hundred millionth of a single DCR (0.00000001 DCR).
-
 
 ## B
 
@@ -33,11 +32,11 @@ The data structure transactions are bundled into before being written into the d
 
 #### Block explorer
 
-A tool for inspecting the contents of blocks in a more user-friendly format. 
+A tool for inspecting the contents of blocks in a more user-friendly format.
 
 #### Block header
 
-Metadata at the beginning of a block that defines information about the block. The hash of a block header is the main way of identifying a block. 
+Metadata at the beginning of a block that defines information about the block. The hash of a block header is the main way of identifying a block.
 
 #### Block reward
 
@@ -46,7 +45,6 @@ A reward (in DCR) split between PoW miners, active and chosen voters, and the Tr
 #### Block voting
 
 In each block, five tickets are called to vote. In addition to votes on any open consensus rule change proposals, each ticket votes to approve or reject the regular transaction tree of the previous block. If a majority of voting tickets vote Yes, the regular transaction tree of the previous block is accepted. If a majority of voting tickets vote No (or there is a tie), the regular transaction tree of the previous block is rejected and those transactions are returned to the mempool.
-
 
 ## C
 
@@ -70,12 +68,11 @@ An interface a user interacts with via the command line - often referring to a C
 
 #### Confirmation
 
-A transaction is confirmed when it has been included in a block that has been verified by the network (added to the blockchain). Each additional block added to the blockchain reconfirms all transactions in all previous blocks. The number of times a transaction has been confirmed is used as a measure of confidence that the transaction will remain in the blockchain. A wallet or other service may require a certain number of confirmations before it considers a transaction to be valid. For example, if a wallet requires three confirmations to consider a transaction valid, it would require the next two blocks after the block including the transaction to confirm the transaction. 
-
+A transaction is confirmed when it has been included in a block that has been verified by the network (added to the blockchain). Each additional block added to the blockchain reconfirms all transactions in all previous blocks. The number of times a transaction has been confirmed is used as a measure of confidence that the transaction will remain in the blockchain. A wallet or other service may require a certain number of confirmations before it considers a transaction to be valid. For example, if a wallet requires three confirmations to consider a transaction valid, it would require the next two blocks after the block including the transaction to confirm the transaction.
 
 #### Consensus rules
 
-Rules, encoded in software, that allow a network of nodes to reach an agreement about the state of the ledger. Rules include what data blocks can contain, how block data is structured, and how nodes validate blocks. 
+Rules, encoded in software, that allow a network of nodes to reach an agreement about the state of the ledger. Rules include what data blocks can contain, how block data is structured, and how nodes validate blocks.
 
 #### Consensus rules voting
 
@@ -88,7 +85,6 @@ A [document](governance/decred-constitution.md) which defines the purpose and gu
 #### Credits
 
 The full unit of the Decred currency (i.e. 1 DCR).
-
 
 ## D
 
@@ -104,7 +100,7 @@ A [design document](https://github.com/decred/dcps) that describes potential pro
 
 #### Decrediton
 
-A GUI (Graphical User Interface) [Decred wallet](https://github.com/decred/decrediton/) maintained by the core team. 
+A GUI (Graphical User Interface) [Decred wallet](https://github.com/decred/decrediton/) maintained by the core team.
 
 #### Difficulty
 
@@ -112,8 +108,11 @@ Difficulty is a measure of how difficult it is to mine a new block (i.e. find a 
 
 #### Distributed ledger
 
-A cryptographically secure ledger, composed of nodes in a network, where each node holds a copy of the same ledger. 
+A cryptographically secure ledger, composed of nodes in a network, where each node holds a copy of the same ledger.
 
+#### Double-spend
+
+A double-spend is an attack where the given set of coins are spent in more than one transaction. A successful double-spend results in inflation by creating new coins which did not previously exist.
 
 ## E
 
@@ -122,7 +121,6 @@ A cryptographically secure ledger, composed of nodes in a network, where each no
 #### Expired ticket
 
 Tickets that reached the end of their window without being called to vote - these can be revoked, but do not grant a reward.
-
 
 ## F
 
@@ -136,7 +134,6 @@ A mechanism for obtaining free (testnet) coins.
 
 Short for 'fully-validating node. Refers to software that fully validates all transactions and blocks, as opposed to trusting a 3rd party. In addition to validating transactions and blocks, nearly all full nodes also participate in relaying transactions and blocks to other full nodes around the world, thus forming the peer-to-peer network that is the backbone of the Decred cryptocurrency.
 
-
 ## G
 
 ---
@@ -144,7 +141,6 @@ Short for 'fully-validating node. Refers to software that fully validates all tr
 #### Genesis block
 
 The very first block of the Decred blockchain, created on the 8th of February 2016.
-
 
 ## H
 
@@ -156,12 +152,11 @@ A dedicated hardware device which stores a wallet's private keys. Examples inclu
 
 #### Hash
 
-The output of a cryptographic hashing function that produces a fixed-size value from variable-size input. While it is computationally easy to create a hash from an input, it is extremely computationally difficult to calculate an input that will produce a given hash. 
-
+The output of a cryptographic hashing function that produces a fixed-size value from variable-size input. While it is computationally easy to create a hash from an input, it is extremely computationally difficult to calculate an input that will produce a given hash.
 
 #### Hash function
 
-A cryptographic function that produces a fixed-size hash value from variable-size transaction input. Decred's Proof-of-Work uses the [BLAKE-256](research/blake-256-hash-function.md) hashing function. 
+A cryptographic function that produces a fixed-size hash value from variable-size transaction input. Decred's Proof-of-Work uses the [BLAKE-256](research/blake-256-hash-function.md) hashing function.
 
 #### Hashrate
 
@@ -175,7 +170,6 @@ A Decred wallet which is connected to the Internet. Proof-of-stake voting wallet
 
 In Decred, a [hybrid PoW/PoS system](research/hybrid-design.md) is used, whereby blocks mined by PoW miners must be approved by ticket holders, which are pseudorandomly selected from the ticket pool. This provides a check on PoW miners and increases the overall cost of attacking the network. When a block is approved, 60% of the block reward goes to the PoW miner, 30% goes to the holders of tickets called to vote (approve blocks), and 10% goes to the Decred Treasury to fund the project.
 
-
 ## I
 
 ---
@@ -188,7 +182,6 @@ Once tickets are mined they are immature for 256 blocks (about 20 hours) and can
 
 Increase in the [available supply](advanced/inflation.md) of Decred as new DCR is minted into existence through the block reward.
 
-
 ## L
 
 ---
@@ -196,7 +189,6 @@ Increase in the [available supply](advanced/inflation.md) of Decred as new DCR i
 #### Live ticket
 
 Tickets that are waiting to be called.
-
 
 ## M
 
@@ -216,16 +208,15 @@ Miners help secure the network via Proof-of-Work (PoW) mining. Miners receive bl
 
 #### Mining Pool
 
-A group of miners who share (pool) their computational resources to mine DCR. When a member of a mining pool successfully mines a block, the rewards are typically split among all pool members in proportion to the hashpower they contribute to the pool. 
+A group of miners who share (pool) their computational resources to mine DCR. When a member of a mining pool successfully mines a block, the rewards are typically split among all pool members in proportion to the hashpower they contribute to the pool.
 
 #### Missed ticket
 
-Tickets that have been called but did not receive a reward. This can happen if a ticket is called to vote, but the wallet that bought the ticket does not respond. This can also happen if the wallet does respond and broadcasts its vote to the network, but a miner does not include their vote in the following block. 
+Tickets that have been called but did not receive a reward. This can happen if a ticket is called to vote, but the wallet that bought the ticket does not respond. This can also happen if the wallet does respond and broadcasts its vote to the network, but a miner does not include their vote in the following block.
 
 #### Multisignature
 
 Multisignature refers to transactions which can be authorized by more than one private key. Multisignature transactions can support multiple keys (N) and a subset of those (M) are required to transact (commonly known as "MofN"). For example, a 2 of 3 multisignature transaction would have three valid keys, however only two of them would be required to authorize.
-
 
 ## N
 
@@ -235,20 +226,17 @@ Multisignature refers to transactions which can be authorized by more than one p
 
 The word nonce is derived from "number used once". In the context of Decred, this usually refers to a 4-byte field in the block header which, along with some additional bytes used as an extra nonce, is adjusted by proof-of-work miners so that the hash of the block is lower than or equal to the current difficulty target of the network.
 
-
 ## O
 
 ---
 
 #### Orphan block
 
-Orphaned blocks are valid blocks which are not included in the definitive blockchain. Orphan blocks can occur when they are part of a branch of the blockchain that has been abandoned. This can occur naturally when two miners produce blocks at similar times. Orphan blocks can also be created when they build on an unknown block (i.e. the "parent" block is unknown, making it an "orphan"). 
-
+Orphaned blocks are valid blocks which are not included in the definitive blockchain. Orphan blocks can occur when they are part of a branch of the blockchain that has been abandoned. This can occur naturally when two miners produce blocks at similar times. Orphan blocks can also be created when they build on an unknown block (i.e. the "parent" block is unknown, making it an "orphan").
 
 #### Orphan transaction
 
-A transaction with missing inputs (i.e. the "parent" transaction is unknown, making the transaction an "orphan"). Orphan transactions can also be created when they are part of a block that has been abandoned and have not been included in another block. For example, if a miner creates a valid block with transactions specific to them, such as coinbase transactions and votes, and that block is orphaned, the transactions in that block will become orphaned transactions. 
-
+A transaction with missing inputs (i.e. the "parent" transaction is unknown, making the transaction an "orphan"). Orphan transactions can also be created when they are part of a block that has been abandoned and have not been included in another block. For example, if a miner creates a valid block with transactions specific to them, such as coinbase transactions and votes, and that block is orphaned, the transactions in that block will become orphaned transactions.
 
 ## P
 
@@ -256,7 +244,7 @@ A transaction with missing inputs (i.e. the "parent" transaction is unknown, mak
 
 #### Politeia
 
-A system for facilitating the submission and discussion of [proposals](https://proposals.decred.org/) in an environment with transparent censorship. 
+A system for facilitating the submission and discussion of [proposals](https://proposals.decred.org/) in an environment with transparent censorship.
 
 #### Private key
 
@@ -264,11 +252,11 @@ An astronomically large number which, when kept secret from others, enables legi
 
 #### Private passphrase
 
-A passphrase that is used to encrypt parts of the wallet.db file; most notably private keys. The private keys can not be accessed unless the passphrase is used to decrypt them. 
+A passphrase that is used to encrypt parts of the wallet.db file; most notably private keys. The private keys can not be accessed unless the passphrase is used to decrypt them.
 
 #### Proof-of-Stake (PoS) voting
 
-The mechanism by which ticket holders vote to approve blocks confirmed by PoW miners (thus providing a check on PoW miners), earn staking rewards, and vote on consensus rule changes and Politeia proposals. 
+The mechanism by which ticket holders vote to approve blocks confirmed by PoW miners (thus providing a check on PoW miners), earn staking rewards, and vote on consensus rule changes and Politeia proposals.
 
 #### Proof-of-Work
 
@@ -276,12 +264,11 @@ The mechanism used by miners to show that they have contributed computational po
 
 #### Protocol rules
 
-See [consensus rules](#consensus-rules). 
+See [consensus rules](#consensus-rules).
 
 #### Public key
 
 An astronomically large number generated algorithmically from a private key. Public keys can be freely shared without revealing any information about the private key they are generated from. The user’s public key is used to prove that a transaction was signed using their private key.
-
 
 ## Q
 
@@ -290,7 +277,6 @@ An astronomically large number generated algorithmically from a private key. Pub
 #### Quorum
 
 The minimum level of participation required in order for a decision-making process to produce an actionable outcome. Changes to the consensus rules require at least 10% of votes to be for or against the change in order to be valid. Politeia proposals require 20%.
-
 
 ## R
 
@@ -302,7 +288,7 @@ The normal [transactions](https://www.reddit.com/r/decred/comments/66j4l4/decred
 
 #### Reorg
 
-A reorganization (or reorg) of the blockchain is when a set of blocks are replaced by another set which has more work. The number of blocks replaced is the depth of the reorg. 
+A reorganization (or reorg) of the blockchain is when a set of blocks are replaced by another set which has more work. The number of blocks replaced is the depth of the reorg.
 
 #### Revoked ticket
 
@@ -310,11 +296,11 @@ When a ticket (that was missed or expired) is revoked, the DCR used to buy it be
 
 #### Rule Change Interval (RCI)
 
-An interval of 8064 blocks (~4 weeks) in which ticket holders can vote on consensus rule changes. A Rule Change Interval (RCI) consists of four Stake Version Intervals (SVI), which are 2016 blocks (~1 week). Once the conditions for a vote have been met during an SVI, voting is scheduled to begin on the first block of the next RCI. Because there are four SVIs per RCI, it can take up to 6048 blocks [3 SVIs] for the next RCI to begin.
+An interval of 8,064 blocks (~4 weeks) in which ticket holders can vote on consensus rule changes. A Rule Change Interval (RCI) consists of four Stake Version Intervals (SVI), which are 2,016 blocks (~1 week). Once the conditions for a vote have been met during an SVI, voting is scheduled to begin on the first block of the next RCI. Because there are four SVIs per RCI, it can take up to 6,048 blocks [3 SVIs] for the next RCI to begin.
 
 #### Rule change proposal
 
-A proposal to change the consensus rules of the Decred blockchain. Rule change proposals must be implemented in latent code within the software running the network's nodes. If the proposal passes, the latent code activates one month later. 
+A proposal to change the consensus rules of the Decred blockchain. Rule change proposals must be implemented in latent code within the software running the network's nodes. If the proposal passes, the latent code activates one month later.
 
 ## S
 
@@ -334,7 +320,7 @@ A [simulation network](advanced/simnet.md) with very low difficulty, such that a
 
 #### Simple Payment Verification (SPV)
 
-A wallet mode in which only blocks related to addresses owned by the wallet are downloaded. When not in SPV mode, wallets must download all blocks in the blockchain to verify transactions (fully validating mode). SPV mode allows wallets to operate with less stringent hardware requirements and load significantly faster. SPV wallets cannot vote, but can purchase tickets and allocate voting rights to a [Voting Service Provider (VSP)](#voting-service-provider). 
+A wallet mode in which only blocks related to addresses owned by the wallet are downloaded. When not in SPV mode, wallets must download all blocks in the blockchain to verify transactions (fully validating mode). SPV mode allows wallets to operate with less stringent hardware requirements and load significantly faster. SPV wallets cannot vote, but can purchase tickets and allocate voting rights to a [Voting Service Provider (VSP)](#voting-service-provider).
 
 #### Stake transaction tree
 
@@ -342,7 +328,7 @@ A wallet mode in which only blocks related to addresses owned by the wallet are 
 
 #### Stake Version Interval (SVI)
 
-An interval of 2016 blocks (~1 week) which is used to determine if a vote on consensus rules can begin. Before a vote on consensus rule changes can begin, 75% of tickets that vote during a Stake Version Interval (SVI) must be using software that contains the latent software change being proposed.
+An interval of 2,016 blocks (~1 week) which is used to determine if a vote on consensus rules can begin. Before a vote on consensus rule changes can begin, 75% of tickets that vote during a Stake Version Interval (SVI) must be using software that contains the latent software change being proposed.
 
 #### Stakebase transaction
 
@@ -355,7 +341,6 @@ See [Voting Service Provider](#voting-service-provider).
 #### Staking
 
 Colloquial term for time-locking DCR in exchange for tickets.
-
 
 ## T
 
@@ -375,11 +360,11 @@ The pool of live tickets that are available to be called to vote. The target siz
 
 #### Ticket price
 
-The amount of DCR one must time-lock in order to buy a ticket. The ticket price is algorithmically adjusted with the goal of keeping the ticket pool at an optimal size of 40,960 tickets. The algorithm for setting the ticket price was changed by [DCP-0001](https://github.com/decred/dcps/blob/master/dcp-0001/dcp-0001.mediawiki), the first consensus rules change to be adopted using an on-chain vote. 
+The amount of DCR one must time-lock in order to buy a ticket. The ticket price is algorithmically adjusted with the goal of keeping the ticket pool at an optimal size of 40,960 tickets. The algorithm for setting the ticket price was changed by [DCP-0001](https://github.com/decred/dcps/blob/master/dcp-0001/dcp-0001.mediawiki), the first consensus rules change to be adopted using an on-chain vote.
 
 #### Ticket-splitting
 
-The process of buying part of a ticket. This is done by coordinating with other parties who will buy the other parts of a ticket. This can be done without giving up custody to your DCR. The minimum amount of DCR that can be put into a split ticket is 5 DCR. Ticket-splitting is currently coordinated through the 'ticket-splitting' channel on the [Decred slack](https://slack.decred.org/) channel. 
+The process of buying part of a ticket. This is done by coordinating with other parties who will buy the other parts of a ticket. This can be done without giving up custody to your DCR. The minimum amount of DCR that can be put into a split ticket is 5 DCR. Ticket-splitting is currently coordinated through the 'ticket-splitting' channel on the [Decred slack](https://slack.decred.org/) channel.
 
 #### Tor
 
@@ -393,7 +378,6 @@ A fee paid to have your transaction included in a block. The default transaction
 
 The [Decred Treasury](https://explorer.dcrdata.org/address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx) holds funds for use in development of the project. Decisions about how to use these funds are made through [Politeia](#politeia) proposals and voting.
 
-
 ## U
 
 ---
@@ -401,7 +385,6 @@ The [Decred Treasury](https://explorer.dcrdata.org/address/Dcur2mcGjmENx4DhNqDct
 #### Unmined ticket
 
 Immediately after a ticket is bought it is unmined until the transaction is included in a block.
-
 
 ## V
 
@@ -418,7 +401,6 @@ People who buy tickets and vote with them.
 #### Voting Service Provider
 
 Non-custodial services that can be authorized to vote on behalf of a ticket, usually providing a number of geographically distributed servers to reduce the chance of missed tickets.
-
 
 ## W
 

--- a/docs/governance/consensus-rule-voting/consensus-rules-voting.md
+++ b/docs/governance/consensus-rule-voting/consensus-rules-voting.md
@@ -1,31 +1,77 @@
 # <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus Rules Voting
 
-This guide was last updated on September 23, 2017.
-
 This page is intended to give a brief introduction to how consensus rule voting works and details the process for setting your tickets to cast your preferred vote for any agenda.
 
 ---
 
 ## Introduction
 
-There is a two-phase process for voting to implement consensus changes that would create a hard forking scenario.
+The consensus rules are a set of rules which every full node participating in the Decred network must enforce when considering the validity of blocks and transactions.
 
-First, it's important to note that the Decred blockchain has specifically designated two different block intervals for the voting process. There is a **Stake Version Interval** (**SVI**) of 2016 blocks (~1 week) and a **Rule Change Interval** (**RCI**) of 8064 blocks (~4 weeks). 4 Stake Version Intervals fit within 1 Rule Change Interval.
+Examples of consensus rules include:
 
-The first step of the voting process is to meet the upgrade threshold on the network. After the hard fork code is released (such as the sdiff algorithm change in v1.0.0), a majority of the nodes on the network participating in PoW/PoS need to first upgrade before the voting can be scheduled to begin. For Proof-of-Work, at least 95% of the 1000 most recent blocks must have the latest block version. For Proof-of-Stake, 75% of the votes cast within a single **SVI** must have the latest vote version. Once miner and voter upgrade thresholds are met, the voting is scheduled to begin on the first block of the next **RCI** (due to there being 4 **SVI**s per **RCI**, it can take up to 6048 blocks [3 **SVI**s] for the next **RCI** to begin).
+- Blocks must not be larger than the maximum permitted size.
+- Decred must not be [double-spent](../../glossary.md#double-spend).
+- Blocks must meet the current [difficulty](../../glossary.md#difficulty) requirement.
 
-The second step of this process is the actual voting. A single **RCI** transpires while a maximum of 40320 votes are cast. The votes are tallied at the final block of the **RCI**, and outcomes are determined prior to the next block being mined.
+It is essential that every node on the network uses exactly the same set of consensus rules.
+Nodes attempting to use consensus rules differing from the majority of the network will not be able to properly validate the blockchain, thus they will not able to participate and will eventually end up operating on their own seperate network.
+
+Decred has a built-in upgrade mechanism which allows consensus rules to be changed across the entire network in a coordinated fashion.
+This enables the rules to be changed predictably and without fracturing the network.
+The process also allows proof-of-stake voters to exercise sovereignty over whether or not to accept the proposed changes.
+
+The process to change the consensus rules is detailed below.
+
+---
+
+## Step 1: Decred Change Proposal (DCP)
+
+A Decred Change Proposal (DCP) is a design document which describes potential protocol or consensus changes to Decred.
+A well written DCP will include a detailed description of the proposed change, explain the motivation for making the change and provide a reference implementation.
+
+Detailed documentation on the format of DCPs, as well as all of the DCPs which have been produced so far, can be found in the  GitHub repository [decred/dcps](https://github.com/decred/dcps).
+
+## Step 2: New node software
+
+New node software which implements the consensus rule changes must be developed and released.
+This new software will include all of the code necessary to enforce the existing consensus rules, as well as the code required to implement the change specified in the DCP.
+The new code implementing the change will lie dormant until the change has been voted upon and accepted by the proof-of-stake voters.
+
+## Step 3: Network upgrade
+
+Proof-of-work miners and proof-of-stake voters must upgrade their software to the new version before voting on activation of the new rules can begin. Each has a different threshold to meet before the upgrade is considered complete:
+
+- The **proof-of-work** upgrade is considered complete once 95% of the latest 1,000 blocks are mined with the latest version
+- The **proof-of-stake** upgrade is considered complete once 75% of the votes in a complete [stake version interval](../../glossary.md#stake-version-interval-svi) are of the latest version
+
+Once both of these thresholds have been met, the vote is scheduled to begin on the first block of the next [rule change interval](../../glossary.md#rule-change-interval-rci).
+
+## Step 4: Voting
+
+Voting takes place across the duration of a full [rule change interval](../../glossary.md#rule-change-interval-rci).
+Each proof-of-stake ticket which is called to vote during this interval will include votebits which indicate whether the ticket holder wishes to accept or reject the new rules, or if they wish to abstain from voting.
+If ticket holders do not explicitly set their voting preference, the default setting is to abstain.
+Given that each block can contain a maximum of five votes, and the rule change interval on mainnet is 8,064 blocks, the maximum number of votes is 40,320.
+Every vote has a quorum requirement of 10%.
+This means that at least 10% of all votes cast must be non-abstain for the result to be considered valid.
 
 There are a few possible outcomes of a vote:
 
-1. If more than 90% of all votes within the RCI are "Abstain" votes, the agenda vote remains active for the next RCI.
-2. If all non-abstaining votes within the RCI fail to meet the 75% Yes or No majority threshold, the agenda vote remains active for next RCI.
-3. If 75% of all non-abstaining votes within the RCI are in support of the agenda ("Yes"), the agenda is considered locked in and the consensus changes will activate 8064 blocks after the vote passed.
-4. If 75% of all non-abstaining votes within the RCI are in opposition of the agenda ("No"), the agenda fails and the consensus changes will never activate.
-5. If an agenda reaches its expiration before ever reaching a 75% majority vote, the agenda expires and the consensus changes will never activate.
+1. If quorum is not met (more than 90% of all votes are "Abstain"), the agenda vote remains active for the next RCI.
+1. If all non-abstaining votes within the RCI fail to meet the 75% Yes or No majority threshold, the agenda vote remains active for next RCI.
+1. If 75% of all non-abstaining votes within the RCI are in support of the agenda ("Yes"), the agenda is considered locked in and the consensus changes will activate 8,064 blocks after the vote passed.
+1. If 75% of all non-abstaining votes within the RCI are in opposition of the agenda ("No"), the agenda fails and the consensus changes will never activate.
+1. If an agenda reaches its expiration before ever reaching a 75% majority vote, the agenda expires and the consensus changes will never activate.
+
+## Step 5. Rule activation
+
+If the quorum requirement is met, and more than 75% of the votes are in favour of activating the new consensus rules, then a "lock-in" period begins.
+This is a fixed period of 8,064 blocks (~4 weeks).
+During this period, all participants in the Decred network **must** upgrade their software to the latest version.
+All full nodes participating in the network will automatically activate the new rules on the first block after this period, so any nodes still running the old software will no longer be able to participate.
 
 Below is a diagram of the entire cycle for a single agenda with consensus upgrades.
-
 
 ![Consensus rule voting cycle](/img/voting-cycle.png)
 
@@ -54,3 +100,9 @@ The block explorer has been updated to display "YES", "NO", and "ABSTAIN" votes 
 ## Tracking Vote Progress
 
 [voting.decred.org](https://voting.decred.org) is an official website set up to track the progress of upgrading and voting.
+
+---
+
+## :fa-book: Further Information
+
+- Blog post announcing Consensus Rules Voting: <https://blog.decred.org/2016/11/16/Upgrading-Consensus/>


### PR DESCRIPTION
Overhaul the consensus vote overview page.
- Brief introduction to what consensus rules are
- Include the DCP stage in the change process
- Make it clear that the code is written and deployed *before* voting, and activated *automatically* if vote is successful
- Link to glossary for explanations of RCI and SVI

Also, in `glossary.md`:
- Add "double-spend"
- Comma seperation for four digit numbers
- General whitespace linting