### PR TITLE
Updates proposal example to comply with updated proposal guidelines

### DIFF
--- a/docs/governance/politeia/example-proposals.md
+++ b/docs/governance/politeia/example-proposals.md
@@ -39,6 +39,8 @@ goals.
 > 3. Add refclient unit tests that validate all 3 conditions.
 > 4. Add RPC to politeiawwwcli so that the status calls can be scripted.
 
+The software implementing the RPC will be published in the Politeia GitHub [repo](https://github.com/decred/politeia) under the [ISC license](https://github.com/decred/politeia/blob/master/LICENSE) that applies to all code in this repo. 
+
 ### Who
 
 In the *Who* section, describe the entity making the proposal, who will
@@ -53,9 +55,9 @@ complete the work, and who will draw down on the proposal's budget.
 In the *When* section, describe the project's milestones, expected 
 completion dates, and the draw schedule (how much DCR is paid for each milestone delivered).
 
-> We proposing doing the design and documentation first and finish the work with the implementation of the code.
-> We allow for some time between the deliverables in order to leave space for a vote by the stakeholders to see if the first step makes sense.
-> Note that this is a small example and therefore the timelines are a bit longish. The milestone votes should be less than a week.
+> We are proposing doing the design and documentation first, then finish the work with the implementation of the code.
+> We allow for some time between the deliverables in order for the community to provide feedback on the initial design and 
+> documentation.
 >
 > 1. 2 hours to design and add documentation on how to use the call with some
 > examples.
@@ -81,6 +83,8 @@ completion dates, and the draw schedule (how much DCR is paid for each milestone
 > 1. Implement politeiawwwcli
 >
 > 15 hours, to be completed on August 29 2018
+>
+> An invoice for all work will be submitted upon completion of all deliverables in an estimated two weeks time. 
 
 
 ## Marketing Proposal


### PR DESCRIPTION
This commit updates the example Politeia proposal for a software fearure, so that it complies with our recently [updated proposal guidelines](https://github.com/decred/dcrdocs/pull/896). Notably, we add which software license the proposed software would use and are clearer on the draw schedule. 