### PR TITLE
Remove decrediton version from ticket splitting guide.

### DIFF
--- a/docs/proof-of-stake/ticket-splitting.md
+++ b/docs/proof-of-stake/ticket-splitting.md
@@ -15,8 +15,8 @@ If you prefer video, try this [tutorial](https://www.youtube.com/watch?v=9L8P7hL
 
 ## Requirements
 
-- **Decrediton wallet:** You will need [Decrediton](../wallets/decrediton/decrediton-setup.md) version 1.2.1 or later to run the Split Ticket Buyer.
-- **5 DCR:** A minimum of 5 DCR (plus transaction fees) is required to participate in ticket splitting. This must be in your wallet, not on an exchange.
+- **Decrediton wallet:** You will need [Decrediton](../wallets/decrediton/decrediton-setup.md) to run the Split Ticket Buyer.
+- **5 DCR:** A minimum of 5 DCR (plus transaction fees) is required to participate in ticket splitting. This must be in your Decrediton wallet, not on an exchange.
 - **Split Ticket Buyer:** This is the software that coordinates ticket splitting with other participants. To install it, download a binary release for your OS [here](https://github.com/matheusd/dcr-split-ticket-matcher/releases/) or [build from source](https://github.com/matheusd/dcr-split-ticket-matcher/blob/master/docs/building.md).
 
 ---


### PR DESCRIPTION
Closes #887 