### PR TITLE
Create a new page for premine.

### DIFF
--- a/docs/advanced/inflation.md
+++ b/docs/advanced/inflation.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Rocket.svg" /> Inflation 
+# <img class="dcr-icon" src="/img/dcr-icons/Rocket.svg" /> Inflation
 
 ---
 
@@ -8,7 +8,7 @@ New blocks are discovered by the proof-of-work miners roughly every 5 minutes, a
 * 30% goes to the PoS voters on that block (6% to each of the 5 voters)
 * 10% goes towards the Decred Treasury
 
-This PoS reward is designed to encourage people to stake their coins and provide the valuable service of approving blocks on the network, but not allow PoS voters to gain share over time simply by staking. PoW miners receive a greater share of the reward than PoS voters to compensate them for securing the network and to encourage a broader distribution of the monetary supply. The 10% block reward to the Decred Treasury helps to ensure the future of Decred by creating a sustainable source of funding for development. 
+This PoS reward is designed to encourage people to stake their coins and provide the valuable service of approving blocks on the network, but not allow PoS voters to gain share over time simply by staking. PoW miners receive a greater share of the reward than PoS voters to compensate them for securing the network and to encourage a broader distribution of the monetary supply. The 10% block reward to the Decred Treasury helps to ensure the future of Decred by creating a sustainable source of funding for development.
 
 The block reward started at 31.19582664 and it adjusts every 6,144 blocks (approximately 21.33 days) by reducing by a factor of 100/101[^1].
 
@@ -20,7 +20,7 @@ The following chart shows an estimate of the coin supply growth over time.
 
 ![Decred supply chart](/img/decred_supply.png)
 
-The table below shows the estimated block reward and estimated total supply of Decred up to block 2,457,600 in 2039. Note that the total supply of DCR at block 1 is 1,680,000 due to the [premine](../faq/general.md#3-how-was-the-decred-premine-distributed). There was no block reward for proof-of-work miners in block 1, which allowed miners to voluntarily choose whether or not to accept the terms of the airdrop independent of a potential reward which could skew the incentive. PoS voting started at block 4,096[^3] therefore PoS rewards were not generated before that height.
+The table below shows the estimated block reward and estimated total supply of Decred up to block 2,457,600 in 2039. Note that the total supply of DCR at block 1 is 1,680,000 due to the [premine](premine.md). There was no block reward for proof-of-work miners in block 1, which allowed miners to voluntarily choose whether or not to accept the terms of the airdrop independent of a potential reward which could skew the incentive. PoS voting started at block 4,096[^3] therefore PoS rewards were not generated before that height.
 
 Block height | Estimated date     | Block reward (DCR) | PoW (DCR)    | PoS vote (DCR) | Decred Treasury (DCR) | Total DCR supply
 ------------ | ------------------ | ------------------ | ------------ | -------------- | ----------------- | ----------------
@@ -430,7 +430,7 @@ Block height | Estimated date     | Block reward (DCR) | PoW (DCR)    | PoS vote
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources 
+## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources
 
 [^1]: [Blockchain parameters](blockchain-parameters.md#blockchain-parameters_1)
 [^2]: GitHub, [decred/dcrd](https://github.com/decred/dcrd/blob/5076a00512a521cea3c51b443b50970804dbe712/blockchain/subsidy_test.go#L52-L54)

--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -1,0 +1,77 @@
+# <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Premine
+
+---
+
+The premine consists of 8% of the total supply of 21 million coins (1.68 million coins). This was split equally between compensation for bring-up costs and an “airdrop”. Full details of the premine transaction can be viewed [on the block explorer](https://explorer.dcrdata.org/tx/5e29cdb355b3fc7e76c98a9983cd44324b3efdd7815c866e33f6c72292cb8be6).
+
+---
+
+## Bring up costs
+
+**840,000 coins, 50% of premine, 4% of total Decred supply**
+
+The development of Decred was funded by Company 0 and from the pockets of its developers individually. The cost of developing the project, in terms of developer pay, totals to approximately USD 300,000, which Company 0 paid to developers. An additional amount of approximately USD 115,000 has been allocated for unpaid work and individual purchases by developers. Company 0 felt that the most equitable way to handle compensation for these expenses was to perform a small premine as part of the project launch. The model is unusual in that no developer received any amount of coins for free – all coins owned by developers were either purchased at a rate of USD 0.49 per coin from their own pockets or exchanged for work performed at the same rate.
+
+This means Company 0 and its developers will have put roughly USD 415,000 into the bring-up since April, 2014 and receive 4% of the total supply, 840,000 coins (at USD 0.49 per coin). Coins held by Company 0 will be used to fund its ongoing work on open source projects, such as Decred and btcsuite.
+
+When Decred launched in February 2016, the developers and project members committed to not trade any of their bring-up DCR for 12 months and Company 0 committed to not trade any for 24 months. These coins will however be used to purchase proof of stake tickets with the intention of making the Decred network harder to attack during its infancy. As the community participation in PoS increases, the amount of tickets purchased using the premine will be reduced proportionally.
+
+---
+
+## Airdrop
+
+**840,000 coins, 50% of premine, 4% of total Decred supply**
+
+Rather than allocating the entire premine to the bring-up costs, the remaining half of the premine was spread evenly across a list of airdrop participants. Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not everybody who signed up was selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions to advance technology in its various forms. There was also a large number of fraudulent sign-ups which needed to be carefully identified and dealt with.
+
+> The airdrop concluded with awarding 282.63795424 DCR to 2,972 participants.
+
+Giving away these coins in an airdrop accomplished several things for the project: enlarging the Decred network, further helping to decentralize the distribution of coins, and getting coins into the hands of people who are interested in participating in the project. These coins were given away unconditionally and there was zero expectation of Decred receiving anything from the participants in return for these coins.
+
+---
+
+## Airdrop Application and Review Process
+
+### Step 1: Registration
+
+Individuals could register their interest in participating in the airdrop by completing an online form which opened on December 15th, 2015 and closed on January 18th, 2016.
+The form required applicants to provide an email address, a link to an online personal profile, and a description of why the participant was interested in Decred or how they intended to contribute to the project.
+This form was submitted 8,793 times, with submissions coming from 99 different countries.
+
+The applications included duplicates, spam and scammers.
+The applications were reviewed and problematic entries were disqualified from the process.
+The process of evaluation involved a combination of:
+
+1. Checking each entry individually for an online presence
+1. Asking the participant directly for more information where the evaluator was unsure about the entry, and/or
+1. Having a discussion with the participant about their interests, history, and proposed future contributions to the project
+
+Checks were also included to investigate similarity in IP addresses and e-mail addresses across entries - this process was performed both manually and using automation.
+
+### Step 2: Confirm Decred Address
+
+Successful applicants from step 1 were sent an email providing instructions on how to download Decred binaries, generate an address, and submit the address through a web form to be included in the airdrop. Address submission closed on January 25th, and in total 3,244 addresses were submitted to the airdrop database.
+
+Once all of the addresses were received, a final inspection was performed on the data provided by each candidate airdrop participant.
+This final and intensive review process worked as follows:
+
+* The sign-up information of each participant was compared with their confirmation information - not only for each user, but also for each user against all other users.
+* The process involved comparison of IP addresses, timestamps, and user agents at both the airdrop sign-up phase and the confirmation phase.
+
+After the final review was completed, 2,972 addresses were included in the airdrop.
+
+---
+
+## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Further Reading
+
+#### Premine Commitments
+
+[The Project's Commitment](https://forum.decred.org/threads/the-projects-commitment.730/)  
+Bitcointalk.org, [[ANN][DCR] Decred - Hybrid PoW/PoS | btcsuite Devs | Tons of New Features | Go](https://bitcointalk.org/index.php?topic=1290358.msg13412287#msg13412287)
+
+#### Airdrop Status Updates
+
+06-Jan-2016 - [Airdrop Status](https://forum.decred.org/threads/airdrop-status.121/)  
+16-Jan-2016 - [Airdrop Conclusion and Road Ahead](https://forum.decred.org/threads/airdrop-conclusion-and-road-ahead.217/)  
+25-Jan-2016 - [Airdrop Rundown](https://forum.decred.org/threads/airdrop-rundown.313/)  
+09-Feb-2016 - [Final Airdrop Review Process](https://forum.decred.org/threads/final-airdrop-review-process.534/)

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -2,16 +2,23 @@
 
 ---
 
-#### 1. What led to the development of Decred? 
+#### 1. What led to the development of Decred?
 
-Here are a series of blog posts that discuss the motivation[^8550] for Decred:
+Here are a series of blog posts that discuss the motivation for Decred:
+
+**Company 0**
 
 * [Iterating Bitcoin](https://blog.companyzero.com/2015/12/iterating-bitcoin/)
 * [Bitcoin's biggest challenges](https://blog.companyzero.com/2015/11/bitcoins-biggest-challenges/)
+* [Decred: Rethink Digital Currency](https://blog.companyzero.com/2015/12/decred-rethink-digital-currency/)
+
+**Decred Digest**
+
+* [Decred: Where did it all begin?](https://thedecreddigest.com/2017/06/10/decred-where-did-it-all-begin/)
 
 ---
 
-#### 2. How do you pronounce Decred? 
+#### 2. How do you pronounce Decred?
 
 The correct pronunciation is in the opening line of the [Decred Constitution](../governance/decred-constitution.md).
 
@@ -20,40 +27,3 @@ Decred (/ˈdi:ˈkred/, /dɪˈkred/, dee-cred)
 ```
 
 In other words, it is a long _e_ as in the word decentralized.
-
----
-
-#### 3. How was the Decred premine distributed? 
-
-The premine consists of 8% of the total supply of 21 million coins (1.68 million coins).[^1] This was split equally between compensation for bring-up costs and an “airdrop”. Full details of the premine transaction can be viewed [on the block explorer](https://explorer.dcrdata.org/tx/5e29cdb355b3fc7e76c98a9983cd44324b3efdd7815c866e33f6c72292cb8be6).
-
-##### Bring up costs (840,000 coins, 50% of premine, 4% of total Decred supply)
-
-The development of Decred was funded by Company 0 and from the pockets of its developers individually. The cost of developing the project, in terms of developer pay, totals to approximately USD 300,000, which Company 0 paid to developers. An additional amount of approximately USD 115,000 has been allocated for unpaid work and individual purchases by developers. Company 0 felt that the most equitable way to handle compensation for these expenses was to perform a small premine as part of the project launch. The model is unusual in that no developer received any amount of coins for free – all coins owned by developers were either purchased at a rate of USD 0.49 per coin from their own pockets or exchanged for work performed at the same rate.
-
-This means Company 0 and its developers will have put roughly USD 415,000 into the bring-up since April, 2014 and receive 4% of the total supply, 840,000 coins (at USD 0.49 per coin). Coins held by Company 0 will be used to fund its ongoing work on open source projects, such as Decred and btcsuite.
-
-When Decred launched in February 2016, the developers and project members committed to not trade any of their bring-up DCR for 12 months and Company 0 committed to not trade any for 24 months.[^4] These coins will however be used to purchase proof of stake tickets with the intention of making the Decred network harder to attack during its infancy. As the community participation in PoS increases, the amount of tickets purchased using the premine will be reduced proportionally. [^5] [^6]
-
-
-##### Airdrop (840,000 coins, 50% of premine, 4% of total Decred supply)
-
-Rather than allocating the entire premine to the bring-up costs, the remaining half of the premine was spread evenly across a list of airdrop participants. Airdrop sign-up was available to anybody and ran through January 2016. Not everybody who signed up was selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions to advance technology in its various forms. There was also a large number of fraudulent sign-ups which needed to be carefully identified and dealt with.[^3] 
-
-> The airdrop concluded with awarding 282.63795424 DCR to 2972 participants.[^2]
-
-Giving away these coins in an airdrop accomplished several things for the project: enlarging the Decred network, further helping to decentralize the distribution of coins, and getting coins into the hands of people who are interested in participating in the project. These coins were given away unconditionally and there was zero expectation of Decred receiving anything from the participants in return for these coins.
-
-
-
----
-
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources 
-
-[^8550]: Decred Forum, [Post 8,550](https://forum.decred.org/threads/567/#post-8550)
-[^1]: Company0 Blog, [December 2015](https://blog.companyzero.com/2015/12/decred-rethink-digital-currency/)
-[^4]: Decred Forum, [The Project's Commitment](https://forum.decred.org/threads/the-projects-commitment.730/)
-[^5]: Bitcointalk.org, [[ANN][DCR] Decred - Hybrid PoW/PoS | btcsuite Devs | Tons of New Features | Go](https://bitcointalk.org/index.php?topic=1290358.msg13412287#msg13412287)
-[^6]: Decred Forum, [How Can We Communicate That Decred Isn't Another Pump And Dump?](https://forum.decred.org/threads/how-can-we-communicate-that-decred-isnt-another-pump-and-dump.96/page-2#post-2220)
-[^3]: Decred Forum, [Final Airdrop Review Process](https://forum.decred.org/threads/final-airdrop-review-process.534/)
-[^2]: GitHub, [decred/dcrd](https://github.com/decred/dcrd/blob/216aa759fa64e5a13ca8a4608e6c80a0f87eff85/chaincfg/premine.go)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
   - 'Blockchain Parameters': 'advanced/blockchain-parameters.md'
   - 'Transaction Details': 'advanced/transaction-details.md'
   - 'Verifying Binaries': 'advanced/verifying-binaries.md'
+  - 'Premine': 'advanced/premine.md'
   - 'Inflation': 'advanced/inflation.md'
   - 'Deleting Your Wallet': 'advanced/deleting-your-wallet.md'
   - 'Navigating Politeia Data': 'advanced/navigating-politeia-data.md'


### PR DESCRIPTION
Moves the existing content out of FAQ and into its own page. Also adds a section on how the airdrop was implemented.

Also adds some extra links:
- extra blog post for origins of decred
- extra links for the premine, airdrop etc.

Relates to #615 