### PR TITLE
Polishes text premine page

### DIFF
--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -2,7 +2,7 @@
 
 ---
 
-When the Decred blockchain launched on Feb 8, 2016, a premine was conducted in which 8% of the total supply of 21 million coins (1.68 million coins) were distributed. Half (4%) went to developers to compensate them for development of the project. The other half (4%) was airdropped evenly across a list of airdrop participants. Details of the development costs and airdrop are outlined below.
+When the Decred blockchain launched, a premine was conducted, in which 8% of the total supply of 21 million coins (1.68 million coins) were distributed. Half (4%) went to Company 0 and its developers to compensate them for work already completed (i.e. "bring up costs"). The other half (4%) was airdropped evenly across a list of airdrop participants. Details of the development costs and airdrop are outlined below.
 
 Full details of the premine transaction can be viewed [on the block explorer](https://explorer.dcrdata.org/tx/5e29cdb355b3fc7e76c98a9983cd44324b3efdd7815c866e33f6c72292cb8be6).
 
@@ -10,23 +10,21 @@ Full details of the premine transaction can be viewed [on the block explorer](ht
 
 ## Bring up costs
 
-**840,000 coins, 50% of premine, 4% of total Decred supply**
+In total, **840,000 coins** (**50% of premine**, **4% of total Decred supply**), were distributed to Company 0 and its developers as compensation for initial development, which was funded out of pocket. 
 
-The development of Decred was funded by Company 0 and from the pockets of its developers individually. The cost of developing the project, in terms of developer pay, totals to approximately USD 300,000, which Company 0 paid to developers. An additional amount of approximately USD 115,000 has been allocated for unpaid work and individual purchases by developers. Company 0 felt that the most equitable way to handle compensation for these expenses was to perform a small premine as part of the project launch. The model is unusual in that no developer received any amount of coins for free – all coins owned by developers were either purchased at a rate of USD 0.49 per coin from their own pockets or exchanged for work performed at the same rate.
+Total development costs paid by Company 0 to developers totaled approximately $300,000. An additional $115,000 was allocated for unpaid work and individual purchases made by developers, bringing total bring-up costs to roughly $415,000. Company 0 felt that the most equitable way to handle compensation for these expenses was to perform a small premine as part of the project launch. This model is unusual in that no developer received any amount of coins for free; all coins owned by developers were either purchased at a rate of $0.49 per coin from their own pockets or exchanged for work performed at the same rate. Coins held by Company 0 were used to fund its ongoing work on open source projects, such as Decred and btcsuite.
 
-This means Company 0 and its developers will have put roughly USD 415,000 into the bring-up since April, 2014 and receive 4% of the total supply, 840,000 coins (at USD 0.49 per coin). Coins held by Company 0 will be used to fund its ongoing work on open source projects, such as Decred and btcsuite.
-
-When Decred launched in February 2016, the developers and project members committed to not trade any of their bring-up DCR for 12 months and Company 0 committed to not trade any for 24 months. These coins will however be used to purchase proof of stake tickets with the intention of making the Decred network harder to attack during its infancy. As the community participation in PoS increases, the amount of tickets purchased using the premine will be reduced proportionally.
+When Decred launched in February 2016, the developers and project members committed to not trade any of their premined DCR for 12 months and Company 0 committed to not trade any for 24 months. These coins were used to purchase Proof-of-Stake (PoS) tickets, with the intention of making the Decred network harder to attack during its infancy. As community participation in PoS has increased, the amount of tickets purchased using premined DCR has reduced proportionally.
 
 ---
 
 ## Airdrop
 
-**840,000 coins, 50% of premine, 4% of total Decred supply**
+In total, **840,000 coins** (**50% of premine**, **4% of total Decred supply**), were distributed evenly across a list of airdrop participants. 
 
-Rather than allocating the entire premine to the bring-up costs, the remaining half of the premine was spread evenly across a list of airdrop participants. Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not everybody who signed up was selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions to advance technology in its various forms. There was also a large number of fraudulent sign-ups which needed to be carefully identified and dealt with.
+Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not all participants who signed up were selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions to advanced technology in its various forms. There were also a large number of fraudulent sign-ups, which were carefully identified and dealt with.
 
-> The airdrop concluded with awarding 282.63795424 DCR to 2,972 participants.
+> When the airdrop concluded, 282.63795424 DCR was awareded to 2,972 participants.
 
 Giving away these coins in an airdrop accomplished several things for the project: enlarging the Decred network, further helping to decentralize the distribution of coins, and getting coins into the hands of people who are interested in participating in the project. These coins were given away unconditionally and there was zero expectation of Decred receiving anything from the participants in return for these coins.
 

--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -2,7 +2,9 @@
 
 ---
 
-The premine consists of 8% of the total supply of 21 million coins (1.68 million coins). This was split equally between compensation for bring-up costs and an “airdrop”. Full details of the premine transaction can be viewed [on the block explorer](https://explorer.dcrdata.org/tx/5e29cdb355b3fc7e76c98a9983cd44324b3efdd7815c866e33f6c72292cb8be6).
+When the Decred blockchain launched on Feb 8, 2016, a premine was conducted in which 8% of the total supply of 21 million coins (1.68 million coins) were distributed. Half (4%) went to developers to compensate them for development of the project. The other half (4%) was airdropped evenly across a list of airdrop participants. Details of the development costs and airdrop are outlined below.
+
+Full details of the premine transaction can be viewed [on the block explorer](https://explorer.dcrdata.org/tx/5e29cdb355b3fc7e76c98a9983cd44324b3efdd7815c866e33f6c72292cb8be6).
 
 ---
 

--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -22,9 +22,9 @@ When Decred launched in February 2016, the developers and project members commit
 
 In total, **840,000 coins** (**50% of premine**, **4% of total Decred supply**), were distributed evenly across a list of airdrop participants. 
 
-Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not all participants who signed up were selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions to advanced technology in its various forms. There were also a large number of fraudulent sign-ups, which were carefully identified and dealt with.
+Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not all participants who signed up were selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions towards advancing technology in its various forms. There were also a large number of fraudulent sign-ups, which were carefully identified and dealt with.
 
-> When the airdrop concluded, 282.63795424 DCR was awareded to 2,972 participants.
+> When the airdrop concluded, 282.63795424 DCR was awarded to 2,972 participants.
 
 Giving away these coins in an airdrop accomplished several things for the project: enlarging the Decred network, further helping to decentralize the distribution of coins, and getting coins into the hands of people who are interested in participating in the project. These coins were given away unconditionally and there was zero expectation of Decred receiving anything from the participants in return for these coins.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
 - Governance:
-  - 'Overview': 'governance/introduction-to-decred-governance.md'
+  - 'Introduction to Decred Governance': 'governance/introduction-to-decred-governance.md'
   - Politeia:
     - 'Overview': 'governance/politeia/overview.md'
     - 'Proposal Guidelines': 'governance/politeia/proposal-guidelines.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
   - 'Obtaining DCR': 'getting-started/obtaining-dcr.md'
   - 'Using the Block Explorer': 'getting-started/using-the-block-explorer.md'
 - Governance:
-  - 'Introduction to Decred Governance': 'governance/introduction-to-decred-governance.md'
+  - 'Overview': 'governance/introduction-to-decred-governance.md'
   - Politeia:
     - 'Overview': 'governance/politeia/overview.md'
     - 'Proposal Guidelines': 'governance/politeia/proposal-guidelines.md'
@@ -135,7 +135,7 @@ nav:
   - 'Schnorr Signatures': 'research/schnorr-signatures.md'
   - 'Miscellaneous Improvements': 'research/miscellaneous-improvements.md'
 - Contributing:
-  - 'Contributing to Decred': 'contributing/contributing-to-decred.md'
+  - 'Overview': 'contributing/contributing-to-decred.md'
   - 'Contributor Compensation': 'contributing/contributor-compensation.md'
   - Guidelines:
     - 'Using GitHub': 'contributing/using-github.md'


### PR DESCRIPTION
This commit polishes text on the new premine page, which was a bit rough. Notably, the page reused text from an old announcement, which was in present tense. Have reworded to use past tense, wordsmithed for flow, and improved formatting. 