### PR TITLE
Adds hardware wallet page

### DIFF
--- a/docs/wallets/hardware-wallets.md
+++ b/docs/wallets/hardware-wallets.md
@@ -1,0 +1,12 @@
+# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Hardware Wallets
+
+A hardware wallet is a device that stores your private keys on a secure piece of hardware, instead
+of in a file on your computer, as is done with [Decrediton](../decrediton/decrediton-setup/) and other software wallets. Hardware wallets
+are generally considered much more secure than software wallets, and easier to use than paper wallets. It is generally 
+recommended that anyone self-custodying significant amounts of crypto not keep it on an exchange or software 
+wallet, but in a hardware wallet or using another more secure method. 
+
+Decred is currently supported on two hardware wallets:
+
+- [Trezor](https://trezor.io/)
+- [Ledger](https://www.ledger.com/) 

--- a/docs/wallets/hardware-wallets.md
+++ b/docs/wallets/hardware-wallets.md
@@ -1,10 +1,7 @@
 # <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Hardware Wallets
 
 A hardware wallet is a device that stores your private keys on a secure piece of hardware, instead
-of in a file on your computer, as is done with [Decrediton](../decrediton/decrediton-setup/) and other software wallets. Hardware wallets
-are generally considered much more secure than software wallets, and easier to use than paper wallets. It is generally 
-recommended that anyone self-custodying significant amounts of crypto not keep it on an exchange or software 
-wallet, but in a hardware wallet or using another more secure method. 
+of in a file on your computer, as is done with [Decrediton](../decrediton/decrediton-setup/) and other software wallets. Hardware wallets provide an additional level of security, and are generally considered more secure than software wallets.
 
 Decred is currently supported on two hardware wallets:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - 'dcrd and dcrwallet CLI Arguments': 'wallets/cli/dcrd-and-dcrwallet-cli-arguments.md'
       - 'dcrctl RPC Commands': 'wallets/cli/dcrctl-rpc-commands.md'
     - 'SPV': 'wallets/spv.md'
+    - 'Hardware Wallets': 'wallets/hardware-wallets.md'
 - Proof-of-Stake Voting:
   - "Overview": 'proof-of-stake/overview.md'
   - "How to Stake": 'proof-of-stake/how-to-stake.md' 


### PR DESCRIPTION
Adding a page on hardware wallets ( Closes #840 ). 

We might want to add more detail to this, such as any DCR-specific instructions/limitations, or short product descriptions?