### PR TITLE
fix side nav menu header color.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,7 +1,8 @@
 /* Override header and footer with decred dark blue*/
 .md-header,
 .md-footer-nav,
-.md-footer-meta {
+.md-footer-meta,
+.md-nav__source {
     background-color: #091440
 }
 


### PR DESCRIPTION
Fix an issue where the top nav menu and collapsed side nav menu were showing the github panel in different colors:

![Screenshot from 2019-04-27 08-13-04](https://user-images.githubusercontent.com/6762864/56846311-b79ee280-68c5-11e9-9e49-625789c27812.png)
![Screenshot from 2019-04-27 08-13-27](https://user-images.githubusercontent.com/6762864/56846312-b79ee280-68c5-11e9-8588-2c40cd3c3c97.png)
