### PR TITLE
Adds transaction example 

### DIFF
--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -132,7 +132,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Tree</td>
 <td><code>00</code></td>
-<td>0 <br>(use regular transaction fee)</td>
+<td>0 <br>(regular transaction tree)</td>
 </tr>
 <tr>
 <td>Sequence number</td>
@@ -155,7 +155,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Tree</td>
 <td><code>00</code></td>
-<td>0 <br>(use regular transaction fee)</td>
+<td>0 <br>(regular transaction tree)</td>
 </tr>
 <tr>
 <td>Sequence number</td>
@@ -183,7 +183,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
-<td style="word-break;">OP_DUP OP_HASH160 f2ccddc70f8b8bcea24a362bf404841d53cbebc0 OP_EQUALVERIFY OP_CHECKSIG <br>(Pay-To-Pubkey (P2Pk) hash script)</td>
+<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 f2ccddc70f8b8bcea24a362bf404841d53cbebc0 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH) script)</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd output</td>
@@ -207,7 +207,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
-<td style="word-break;">OP_DUP OP_HASH160 1a1f5c7e9f7696989dced5cb9b61464f95790b72 OP_EQUALVERIFY OP_CHECKSIG <br>(Pay-To-Pubkey (P2Pk) hash script)</td>
+<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 1a1f5c7e9f7696989dced5cb9b61464f95790b72 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH) script)</td>
 </tr>
 <tr>
 <td>Lock time</td>
@@ -250,7 +250,8 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
-<td>2 data pushes. 1st push is DER signature. 2nd push is public key</td>
+<td style="word-break: break-all;">
+  The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature (asm))<br><code>30440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da16801</code><br><br>2nd push<br>(public key)<br><br><code>024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd witness</td>
@@ -278,7 +279,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
-<td>2 data pushes. 1st push is DER signature. 2nd push is public key</td>
+<td style="word-break: break-all;">The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature (asm))<br><code style="word-break: break-all">3045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e 57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201</code><br><br>2nd push<br>(public key)<br><br><code style="word-break: break-all;">0307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
 </tr>
 </tbody>
 </table>

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -75,3 +75,64 @@ The witness data of a transaction involves only its inputs. The included data fi
 * **1 (No witness)** - The transaction's prefix is the only data present.
 * **2 (Only witness)** - The transaction's witness data is the only data present. For each input, this includes its value, block height, block index, and signature script.
 
+## Example Transaction
+
+Below we examine an [example transaction](https://explorer.dcrdata.org/tx/a58389bd42520a9b9ecbae5432e27b91fde74d2f8e74ac6f8c22cda57b8ae348) from the Decred mainnet.
+
+### Raw Transaction (Hex)
+
+Here is the raw hex data for the example transaction.
+
+`01000000024ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f540100000000ffffffffc619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac570100000000ffffffff0291c2e26d0200000000001976a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088acd676dd680100000000001976a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac000000000000000002ca68865402000000a29c0400040000006a4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c49743a82010000009e9c0400010000006b483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7`
+
+
+### Transaction Breakdown
+
+Below is a breakdown of the above raw hex transaction data into fields. This transaction uses the full serialization format, so we can see witness data along with inputs and outputs. Note that hex values are in little-endian format.
+
+Field        | Value        | Description
+---          | ---          | ---
+Version      | `01`  | Version: 1
+Serialization format  | `00`  | Serialization: Full serialization
+Number inputs |  `000002`     | Inputs: 2                                              
+1st input | `4ff2,8b53,4361,e383,b5b1,49df,4572,feb1,fbc6,59cb,0706,7c3c,b6c6,8445,2ae7,9f54`                 | Transaction hash
+      | `0100,0000`                                              | Output index: 1
+    | `00`       | Tree: 0
+       | `ffff,ffff`                     | Sequence number: 4294967295
+2nd input | `c619,e6ad,e3f4,69b8,bb60,b8ae,9b05,99ee,eca0,5cd2,db25,1cad,ea44,3344,eafd,ac57`                 | Transaction hash
+      | `0100,0000`                                              | Output index: 1
+    | `00`       | Tree: 0
+       | `ffff,ffff`                     | Sequence number: 4294967295
+1st output | `91c2,e26d,0200,0000`                 | Output amount: 104.33
+      | `0000`                                              | Version: 0
+    | `19`       | Public key script (length): 25
+       | `76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac`                     | Public key script
+2nd output | `d676,dd68,0100,0000`                 | Output amount: 60.54
+      | `0000`                                              | Version: 0
+    | `19`       | Public key script (length): 25
+       | `76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac`                     | Public key script
+Lock time      | `00000000`  | Lock time: 0 
+Expiry     | `00000000`  | Expiry: 0
+Number witnesses     | `02`  | Witnesses: 2
+1st witness    | `ca68,8654,0200,0000`  | Input amount: 100.08
+    | `a29c,0400`  | Block height: 302242
+        | `0400,0000`  | Block index: 4
+        | `6a`  | Signature script (length): 106
+        | `4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c`  | Signature script 
+2nd witness    | `4974,3a82,0100,0000`  | Input amount: 64.79
+    | `9e9c,0400`  | Block height: 302238
+        | `0100,0000`  | Block index: 1
+        | `6b`  | Signature script (length): 107
+        | `483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7`  | Signature script 
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -78,7 +78,7 @@ The witness data of a transaction involves only its inputs. The included data fi
 
 ## Example Transaction
 
-Below we examine an [example transaction](https://explorer.dcrdata.org/tx/a58389bd42520a9b9ecbae5432e27b91fde74d2f8e74ac6f8c22cda57b8ae348) from the Decred mainnet.
+Below we examine an example [transaction](https://explorer.dcrdata.org/tx/a58389bd42520a9b9ecbae5432e27b91fde74d2f8e74ac6f8c22cda57b8ae348) from the Decred mainnet.
 
 ### Raw Transaction (Hex)
 
@@ -89,7 +89,7 @@ Here is the raw hex data for the example transaction.
 
 ### Transaction Breakdown
 
-Below is a breakdown of the above raw hex transaction data into fields. This transaction uses the full serialization format, so we can see witness data along with inputs and outputs. Note that hex values are in little-endian format.
+Below is a breakdown of the above raw hex transaction data into fields. This transaction uses the full serialization format, so we can see witness data along with inputs and outputs. 
 
 Field        | Value        | Description
 ---          | ---          | ---

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -91,49 +91,193 @@ Here is the raw hex data for the example transaction.
 
 Below is a breakdown of the above raw hex transaction data into fields. This transaction uses the full serialization format, so we can see witness data along with inputs and outputs. 
 
-Field        | Value        | Description
----          | ---          | ---
-Version      | `01`  | Version: 1
-Serialization format  | `00`  | Serialization: Full serialization
-Number inputs |  `000002`     | Inputs: 2                                              
-1st input | `4ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f54`                 | Transaction hash
-      | `01000000`                                              | Output index: 1
-    | `00`       | Tree: 0
-       | `ffffffff`                     | Sequence number: 4294967295
-2nd input | `c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57`                 | Transaction hash
-      | `01000000`                                              | Output index: 1
-    | `00`       | Tree: 0
-       | `ffffffff`                     | Sequence number: 4294967295
-1st output | `91c2e26d02000000`                 | Output amount: 104.33
-      | `0000`                                              | Version: 0
-    | `19`       | Public key script (length): 25
-       | `76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac`                     | Public key script
-2nd output | `d676dd6801000000`                 | Output amount: 60.54
-      | `0000`                                              | Version: 0
-    | `19`       | Public key script (length): 25
-       | `76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac`                     | Public key script
-Lock time      | `00000000`  | Lock time: 0 
-Expiry     | `00000000`  | Expiry: 0
-Number witnesses     | `02`  | Witnesses: 2
-1st witness    | `ca68865402000000`  | Input amount: 100.08
-    | `a29c0400`  | Block height: 302242
-        | `04000000`  | Block index: 4
-        | `6a`  | Signature script (length): 106
-        | `4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c`  | Signature script 
-2nd witness    | `49743a8201000000`  | Input amount: 64.79
-    | `9e9c0400`  | Block height: 302238
-        | `01000000`  | Block index: 1
-        | `6b`  | Signature script (length): 107
-        | `483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7`  | Signature script 
-
-
-
-
-
-
-
-
-
-
-
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Version</td>
+<td><code>01</code></td>
+<td>1</td>
+</tr>
+<tr>
+<td>Serialization format</td>
+<td><code>00</code></td>
+<td>Full serialization</td>
+</tr>
+<tr>
+<td>Number inputs</td>
+<td><code>000002</code></td>
+<td>2</td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">1st input</td>
+</tr>
+<td>Transaction hash</td>
+<td><code>4ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f54</code></td>
+<td></td>
+</tr>
+<tr>
+<td>Output index</td>
+<td><code>01000000</code></td>
+<td>1</td>
+</tr>
+<tr>
+<td>Tree</td>
+<td><code>00</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Sequence number</td>
+<td><code>ffffffff</code></td>
+<td>4294967295</td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">2nd input</td>
+</tr>
+<tr>
+  <td>Transaction hash</td>
+<td><code>c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57</code></td>
+<td></td>
+</tr>
+<tr>
+<td>Output index</td>
+<td><code>01000000</code></td>
+<td>1</td>
+</tr>
+<tr>
+<td>Tree</td>
+<td><code>00</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Sequence number</td>
+<td><code>ffffffff</code></td>
+<td>4294967295</td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">1st output</td>
+</tr>
+<tr>
+<td>Output amount</td>
+<td><code>91c2e26d02000000</code></td>
+<td>104.33</td>
+</tr>
+<tr>
+<td>Version</td>
+<td><code>0000</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Public key script length</td>
+<td><code>19</code></td>
+<td>25</td>
+</tr>
+<tr>
+<td>Public key script</td>
+<td><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">2nd output</td>
+</tr>
+<tr>
+<td>Output amount</td>
+<td><code>d676dd6801000000</code></td>
+<td>60.54</td>
+</tr>
+<tr>
+<td>Version</td>
+<td><code>0000</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Public key script length</td>
+<td><code>19</code></td>
+<td>25</td>
+<td></td>
+</tr>
+<tr>
+<td>Public key script</td>
+<td><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
+<td></td>
+</tr>
+<tr>
+<td>Lock time</td>
+<td><code>00000000</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Expiry</td>
+<td><code>00000000</code></td>
+<td>0</td>
+</tr>
+<tr>
+<td>Number witnesses</td>
+<td><code>02</code></td>
+<td>2</td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">1st witness</td>
+</tr>
+<tr>
+  <td>Input amount</td>
+<td><code>ca68865402000000</code></td>
+<td>100.08</td>
+</tr>
+<tr>
+<td>Block height</td>
+<td><code>a29c0400</code></td>
+<td>302242</td>
+</tr>
+<tr>
+<td>Block index</td>
+<td><code>04000000</code></td>
+<td>4</td>
+</tr>
+<tr>
+<td>Signature script length</td>
+<td><code>6a</code></td>
+<td>106</td>
+</tr>
+<tr>
+<td>Signature script</td>
+<td><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="3" style="text-align: center;">2nd witness</td>
+</tr>
+<tr>
+<td>Input amount</td>
+<td><code>49743a8201000000</code></td>
+<td>64.79</td>
+</tr>
+<tr>
+<td>Block height: 302238</td>
+<td><code>9e9c0400</code></td>
+<td>302238</td>
+</tr>
+<tr>
+<td>Block index: 1</td>
+<td><code>01000000</code></td>
+<td>1</td>
+</tr>
+<tr>
+<td>Signature script length</td>
+<td><code>6b</code></td>
+<td>107</td>
+</tr>
+<tr>
+<td>Signature script</td>
+<td><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
+<td></td>
+</tr>
+</tbody>
+</table>
 

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -84,14 +84,16 @@ Below we examine an example [transaction](https://explorer.dcrdata.org/tx/a58389
 
 Here is the raw hex data for the example transaction.
 
-`01000000024ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f540100000000ffffffffc619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac570100000000ffffffff0291c2e26d0200000000001976a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088acd676dd680100000000001976a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac000000000000000002ca68865402000000a29c0400040000006a4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c49743a82010000009e9c0400010000006b483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7`
+```no-highlight
+01000000024ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f540100000000ffffffffc619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac570100000000ffffffff0291c2e26d0200000000001976a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088acd676dd680100000000001976a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac000000000000000002ca68865402000000a29c0400040000006a4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c49743a82010000009e9c0400010000006b483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7
+```
 
 
 ### Transaction Breakdown
 
 Below is a breakdown of the above raw hex transaction data into fields. This transaction uses the full serialization format, so we can see witness data along with inputs and outputs. 
 
-<table>
+<table style="overflow-wrap: break-word;">
 <thead>
 <tr>
 <th>Field</th>
@@ -119,7 +121,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <td colspan="3" style="text-align: center;">1st input</td>
 </tr>
 <td>Transaction hash</td>
-<td><code>4ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f54</code></td>
+<td style="word-break: break-all;"><code>4ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f54</code></td>
 <td></td>
 </tr>
 <tr>
@@ -142,7 +144,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 </tr>
 <tr>
   <td>Transaction hash</td>
-<td><code>c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57</code></td>
+<td style="word-break: break-all;"><code>c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57</code></td>
 <td></td>
 </tr>
 <tr>
@@ -180,7 +182,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 </tr>
 <tr>
 <td>Public key script</td>
-<td><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
+<td style="word-break: break-all;"><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
 <td></td>
 </tr>
 <tr>
@@ -204,7 +206,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 </tr>
 <tr>
 <td>Public key script</td>
-<td><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
+<td style="word-break: break-all;"><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
 <td></td>
 </tr>
 <tr>
@@ -247,7 +249,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 </tr>
 <tr>
 <td>Signature script</td>
-<td><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
+<td style="word-break: break-all;"><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
 <td></td>
 </tr>
 <tr>
@@ -275,7 +277,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 </tr>
 <tr>
 <td>Signature script</td>
-<td><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
+<td style="word-break: break-all;"><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
 <td></td>
 </tr>
 </tbody>

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -42,6 +42,7 @@ Field            | Description
 Value            | The amount of coins that the output being spent transfers.
 Block height     | The height of the block containing the transaction in which the output being spent is located.
 Block index      | The index of the transaction in which the output being spent is located.
+Signature script length | The length of the signature script as a variable-length integer 
 Signature script | The script that satisfies the requirements of the script in the output being spent.
 
 
@@ -95,33 +96,33 @@ Field        | Value        | Description
 Version      | `01`  | Version: 1
 Serialization format  | `00`  | Serialization: Full serialization
 Number inputs |  `000002`     | Inputs: 2                                              
-1st input | `4ff2,8b53,4361,e383,b5b1,49df,4572,feb1,fbc6,59cb,0706,7c3c,b6c6,8445,2ae7,9f54`                 | Transaction hash
-      | `0100,0000`                                              | Output index: 1
+1st input | `4ff28b534361e383b5b149df4572feb1fbc659cb07067c3cb6c684452ae79f54`                 | Transaction hash
+      | `01000000`                                              | Output index: 1
     | `00`       | Tree: 0
-       | `ffff,ffff`                     | Sequence number: 4294967295
-2nd input | `c619,e6ad,e3f4,69b8,bb60,b8ae,9b05,99ee,eca0,5cd2,db25,1cad,ea44,3344,eafd,ac57`                 | Transaction hash
-      | `0100,0000`                                              | Output index: 1
+       | `ffffffff`                     | Sequence number: 4294967295
+2nd input | `c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57`                 | Transaction hash
+      | `01000000`                                              | Output index: 1
     | `00`       | Tree: 0
-       | `ffff,ffff`                     | Sequence number: 4294967295
-1st output | `91c2,e26d,0200,0000`                 | Output amount: 104.33
+       | `ffffffff`                     | Sequence number: 4294967295
+1st output | `91c2e26d02000000`                 | Output amount: 104.33
       | `0000`                                              | Version: 0
     | `19`       | Public key script (length): 25
        | `76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac`                     | Public key script
-2nd output | `d676,dd68,0100,0000`                 | Output amount: 60.54
+2nd output | `d676dd6801000000`                 | Output amount: 60.54
       | `0000`                                              | Version: 0
     | `19`       | Public key script (length): 25
        | `76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac`                     | Public key script
 Lock time      | `00000000`  | Lock time: 0 
 Expiry     | `00000000`  | Expiry: 0
 Number witnesses     | `02`  | Witnesses: 2
-1st witness    | `ca68,8654,0200,0000`  | Input amount: 100.08
-    | `a29c,0400`  | Block height: 302242
-        | `0400,0000`  | Block index: 4
+1st witness    | `ca68865402000000`  | Input amount: 100.08
+    | `a29c0400`  | Block height: 302242
+        | `04000000`  | Block index: 4
         | `6a`  | Signature script (length): 106
         | `4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c`  | Signature script 
-2nd witness    | `4974,3a82,0100,0000`  | Input amount: 64.79
-    | `9e9c,0400`  | Block height: 302238
-        | `0100,0000`  | Block index: 1
+2nd witness    | `49743a8201000000`  | Input amount: 64.79
+    | `9e9c0400`  | Block height: 302238
+        | `01000000`  | Block index: 1
         | `6b`  | Signature script (length): 107
         | `483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7`  | Signature script 
 

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -132,12 +132,12 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Tree</td>
 <td><code>00</code></td>
-<td>0</td>
+<td>0 <br>(use regular transaction fee)</td>
 </tr>
 <tr>
 <td>Sequence number</td>
 <td><code>ffffffff</code></td>
-<td>4294967295</td>
+<td>4294967295 <br>(transaction finalized)</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd input</td>
@@ -155,12 +155,12 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Tree</td>
 <td><code>00</code></td>
-<td>0</td>
+<td>0 <br>(use regular transaction fee)</td>
 </tr>
 <tr>
 <td>Sequence number</td>
 <td><code>ffffffff</code></td>
-<td>4294967295</td>
+<td>4294967295 <br>(transaction finalized)</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">1st output</td>
@@ -168,10 +168,10 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Output amount</td>
 <td><code>91c2e26d02000000</code></td>
-<td>104.33</td>
+<td>104.33512081</td>
 </tr>
 <tr>
-<td>Version</td>
+<td>Script Version</td>
 <td><code>0000</code></td>
 <td>0</td>
 </tr>
@@ -183,7 +183,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
-<td></td>
+<td style="word-break;">OP_DUP OP_HASH160 f2ccddc70f8b8bcea24a362bf404841d53cbebc0 OP_EQUALVERIFY OP_CHECKSIG <br>(Pay-To-Pubkey (P2Pk) hash script)</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd output</td>
@@ -191,10 +191,10 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Output amount</td>
 <td><code>d676dd6801000000</code></td>
-<td>60.54</td>
+<td>60.54311638</td>
 </tr>
 <tr>
-<td>Version</td>
+<td>Script Version</td>
 <td><code>0000</code></td>
 <td>0</td>
 </tr>
@@ -207,7 +207,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
-<td></td>
+<td style="word-break;">OP_DUP OP_HASH160 1a1f5c7e9f7696989dced5cb9b61464f95790b72 OP_EQUALVERIFY OP_CHECKSIG <br>(Pay-To-Pubkey (P2Pk) hash script)</td>
 </tr>
 <tr>
 <td>Lock time</td>
@@ -230,7 +230,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
   <td>Input amount</td>
 <td><code>ca68865402000000</code></td>
-<td>100.08</td>
+<td>100.08029386</td>
 </tr>
 <tr>
 <td>Block height</td>
@@ -250,7 +250,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
-<td></td>
+<td>2 data pushes. 1st push is DER signature. 2nd push is public key</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd witness</td>
@@ -258,7 +258,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Input amount</td>
 <td><code>49743a8201000000</code></td>
-<td>64.79</td>
+<td>64.79836233</td>
 </tr>
 <tr>
 <td>Block height: 302238</td>
@@ -278,7 +278,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
-<td></td>
+<td>2 data pushes. 1st push is DER signature. 2nd push is public key</td>
 </tr>
 </tbody>
 </table>

--- a/docs/advanced/transaction-details.md
+++ b/docs/advanced/transaction-details.md
@@ -143,7 +143,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <td colspan="3" style="text-align: center;">2nd input</td>
 </tr>
 <tr>
-  <td>Transaction hash</td>
+<td>Transaction hash</td>
 <td style="word-break: break-all;"><code>c619e6ade3f469b8bb60b8ae9b0599eeeca05cd2db251cadea443344eafdac57</code></td>
 <td></td>
 </tr>
@@ -183,7 +183,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a914f2ccddc70f8b8bcea24a362bf404841d53cbebc088ac</code></td>
-<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 f2ccddc70f8b8bcea24a362bf404841d53cbebc0 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH) script)</td>
+<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 f2ccddc70f8b8bcea24a362bf404841d53cbebc0 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH)<br> script)</td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd output</td>
@@ -202,22 +202,21 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <td>Public key script length</td>
 <td><code>19</code></td>
 <td>25</td>
-<td></td>
 </tr>
 <tr>
 <td>Public key script</td>
 <td style="word-break: break-all;"><code>76a9141a1f5c7e9f7696989dced5cb9b61464f95790b7288ac</code></td>
-<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 1a1f5c7e9f7696989dced5cb9b61464f95790b72 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH) script)</td>
+<td style="word-break: break-all; word-wrap: break-word;">OP_DUP OP_HASH160 1a1f5c7e9f7696989dced5cb9b61464f95790b72 OP_EQUALVERIFY OP_CHECKSIG <br><br>(Pay-To-Pubkey-Hash (P2PKH)<br> script)</td>
 </tr>
 <tr>
 <td>Lock time</td>
 <td><code>00000000</code></td>
-<td>0</td>
+<td>0<br>(no lock time)</td>
 </tr>
 <tr>
 <td>Expiry</td>
 <td><code>00000000</code></td>
-<td>0</td>
+<td>0<br>(no expiry)</td>
 </tr>
 <tr>
 <td>Number witnesses</td>
@@ -228,7 +227,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <td colspan="3" style="text-align: center;">1st witness</td>
 </tr>
 <tr>
-  <td>Input amount</td>
+<td>Input amount</td>
 <td><code>ca68865402000000</code></td>
 <td>100.08029386</td>
 </tr>
@@ -251,7 +250,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>4730440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da1680121024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
 <td style="word-break: break-all;">
-  The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature (asm))<br><code>30440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da16801</code><br><br>2nd push<br>(public key)<br><br><code>024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
+  The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature)<br><code>30440220139466bd10b1f071f9b4ac16ed434d63d090613fd06470f7bca9bba2b6ea6a0a02203cad1297ab9384466b3f304cd61e7e4ffa9abc1ae9fe1630207fae6f200da16801</code><br><br>2nd push<br>(public key)<br><br><code>024d540859b805c5780f2f0da350df8757c1defb72e3381b252d20874478a5549c</code></td>
 </tr>
 <tr>
 <td colspan="3" style="text-align: center;">2nd witness</td>
@@ -279,7 +278,7 @@ Below is a breakdown of the above raw hex transaction data into fields. This tra
 <tr>
 <td>Signature script</td>
 <td style="word-break: break-all;"><code>483045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201210307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
-<td style="word-break: break-all;">The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature (asm))<br><code style="word-break: break-all">3045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e 57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201</code><br><br>2nd push<br>(public key)<br><br><code style="word-break: break-all;">0307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
+<td style="word-break: break-all;">The signature script contains two <br>pieces of data to be pushed onto<br> the stack:<br><br>1st push<br>(DER signature<br><code style="word-break: break-all">3045022100da5b0fde58c4c57a88d96f83b02eddcb67b1b68ce95cc562c895f2e4e 57bb44302201a8744aed654d2979bdd797187f6bf63ad1898c5d5c585309eeca558742858b201</code><br><br>2nd push<br>(public key)<br><br><code style="word-break: break-all;">0307e3d98b004b15561c0f5aa158c90f93de33756d3bfd1f8a1058a4d90ffc7ec7</code></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Adds an example transaction to the [Transaction Details](https://docs.decred.org/advanced/transaction-details/) page ( Closes #765 ). 

Note: the transaction fields were broken down according to the example tx provided in #765 by @davecgh, and when parsing the data I ended up moving a couple bytes around. E.g. `script version` in the example was `0000`, but the docs say this is a two byte field, so have used `00` and moved the subsequent `00` into the next field (`script length`). There are also a couple fields that need double checking, such as `public key signature length` (hex evaluating to 25, though looks like the script has 50 bytes?) and `signature script length`. 

Also, the markdown table is a bit wonky, due to the fact that markdown doesn't support spanning cells. Can tweak the formatting with inline html, but wanted to get a first pass review on the current table first. We could also just use text formatting like we do for the block header [example](https://docs.decred.org/advanced/block-header-specifications/).

Also, do we want to paste a link to the full decoded tx JSON?
https://explorer.dcrdata.org/api/tx/decoded/a58389bd42520a9b9ecbae5432e27b91fde74d2f8e74ac6f8c22cda57b8ae348?indent=true