### PR TITLE
1st draft LN page

### DIFF
--- a/docs/wallets/lightning.md
+++ b/docs/wallets/lightning.md
@@ -4,7 +4,7 @@
 
 ## What is Lightning (LN)?
 
-The Lighning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wiki/Lightning_Network) that runs on top of the base layer Decred blockchain ("Layer 1"). It enables fast, low cost transactions and higher throughput than possible on Layer 1. 
+The Lightning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wiki/Lightning_Network) that runs on top of the base layer Decred blockchain ("Layer 1"). It enables fast, low cost transactions and higher throughput than possible on Layer 1. 
 
 ## Decred Lightning Implemetation
 

--- a/docs/wallets/lightning.md
+++ b/docs/wallets/lightning.md
@@ -4,7 +4,7 @@
 
 ## What is Lightning (LN)?
 
-The Lightning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wiki/Lightning_Network) that runs on top of the base layer Decred blockchain ("Layer 1"). It enables fast, low cost transactions and higher throughput than possible on Layer 1. 
+The Lightning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wiki/Lightning_Network) that runs on top of the base layer ("Layer 1") of a blockchain-based cryptocurrency (like Decred). It enables fast, low cost transactions and higher throughput than possible on Layer 1. 
 
 ## Decred Lightning Implemetation
 

--- a/docs/wallets/lightning.md
+++ b/docs/wallets/lightning.md
@@ -8,6 +8,6 @@ The Lightning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wi
 
 ## Decred Lightning Implemetation
 
-Decred's Lightning Network implementation ([dcrlnd](https://github.com/decred/dcrlnd)) is based on the [lnd](https://github.com/lightningnetwork/lnd) implementation for Bitcoin, and is under active development. While the Lightning Network was activated on the Decred mainnet with the activation of [DCP-0004](../../governance/consensus-rule-voting/consensus-vote-archive/#update-sequence-lock-rules) at block [342784](https://explorer.dcrdata.org/block/342784) (May 9th, 2019), and is operational on mainnet, it is not recommended to put any significant amounts of DCR into LND nodes until the implementation is more mature. For more on the technical details of LN, see the [dcrlnd](https://github.com/decred/dcrlnd) repo. 
+Decred's Lightning Network implementation ([dcrlnd](https://github.com/decred/dcrlnd)) is based on the [lnd](https://github.com/lightningnetwork/lnd) implementation for Bitcoin, and is under active development. While the Lightning Network was activated on the Decred mainnet with the activation of [DCP-0004](../../governance/consensus-rule-voting/consensus-vote-archive/#update-sequence-lock-rules) at block [342784](https://dcrdata.decred.org/block/342784) (May 9th, 2019), and is operational on mainnet, it is not recommended to put any significant amounts of DCR into LND nodes until the implementation is more mature. For more on the technical details of LN, see the [dcrlnd](https://github.com/decred/dcrlnd) repo. 
 
 

--- a/docs/wallets/lightning.md
+++ b/docs/wallets/lightning.md
@@ -8,6 +8,6 @@ The Lighning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wik
 
 ## Decred Lightning Implemetation
 
-Decred's Lightening Network implementation ([dcrlnd](https://github.com/decred/dcrlnd)) is based on the [lnd](https://github.com/lightningnetwork/lnd) implementation for Bitcoin, and is under active development. While the Lightening Network was activated on the Decred mainnet with the activation of [DCP-0004](../../governance/consensus-rule-voting/consensus-vote-archive/#update-sequence-lock-rules) at block [342784](https://explorer.dcrdata.org/block/342784) (May 9th, 2019), and is operational on mainnet, it is not recommended to put any significant amounts of DCR into LND nodes until the implementation is more mature. For more on the technical details of LN, see the [dcrlnd](https://github.com/decred/dcrlnd) repo. 
+Decred's Lightning Network implementation ([dcrlnd](https://github.com/decred/dcrlnd)) is based on the [lnd](https://github.com/lightningnetwork/lnd) implementation for Bitcoin, and is under active development. While the Lightning Network was activated on the Decred mainnet with the activation of [DCP-0004](../../governance/consensus-rule-voting/consensus-vote-archive/#update-sequence-lock-rules) at block [342784](https://explorer.dcrdata.org/block/342784) (May 9th, 2019), and is operational on mainnet, it is not recommended to put any significant amounts of DCR into LND nodes until the implementation is more mature. For more on the technical details of LN, see the [dcrlnd](https://github.com/decred/dcrlnd) repo. 
 
 

--- a/docs/wallets/lightning.md
+++ b/docs/wallets/lightning.md
@@ -1,0 +1,13 @@
+# Lightning Network (LN)
+
+---
+
+## What is Lightning (LN)?
+
+The Lighning Network (LN) is a "Layer 2" [protocol](https://en.wikipedia.org/wiki/Lightning_Network) that runs on top of the base layer Decred blockchain ("Layer 1"). It enables fast, low cost transactions and higher throughput than possible on Layer 1. 
+
+## Decred Lightning Implemetation
+
+Decred's Lightening Network implementation ([dcrlnd](https://github.com/decred/dcrlnd)) is based on the [lnd](https://github.com/lightningnetwork/lnd) implementation for Bitcoin, and is under active development. While the Lightening Network was activated on the Decred mainnet with the activation of [DCP-0004](../../governance/consensus-rule-voting/consensus-vote-archive/#update-sequence-lock-rules) at block [342784](https://explorer.dcrdata.org/block/342784) (May 9th, 2019), and is operational on mainnet, it is not recommended to put any significant amounts of DCR into LND nodes until the implementation is more mature. For more on the technical details of LN, see the [dcrlnd](https://github.com/decred/dcrlnd) repo. 
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
       - 'dcrd and dcrwallet CLI Arguments': 'wallets/cli/dcrd-and-dcrwallet-cli-arguments.md'
       - 'dcrctl RPC Commands': 'wallets/cli/dcrctl-rpc-commands.md'
     - 'SPV': 'wallets/spv.md'
-    - 'Lighning Network (LN)': 'wallets/lightning.md'
+    - 'Lightning Network (LN)': 'wallets/lightning.md'
     - 'Hardware Wallets': 'wallets/hardware-wallets.md'
 - Proof-of-Stake Voting:
   - "Overview": 'proof-of-stake/overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - 'dcrd and dcrwallet CLI Arguments': 'wallets/cli/dcrd-and-dcrwallet-cli-arguments.md'
       - 'dcrctl RPC Commands': 'wallets/cli/dcrctl-rpc-commands.md'
     - 'SPV': 'wallets/spv.md'
+    - 'Lighning Network (LN)': 'wallets/lightning.md'
     - 'Hardware Wallets': 'wallets/hardware-wallets.md'
 - Proof-of-Stake Voting:
   - "Overview": 'proof-of-stake/overview.md'


### PR DESCRIPTION
This PR creates a simple 'Lightning Network (LN)' page under wallets. There's a lot of info I can think to add here (Decredition support, how to set up and operate nodes, etc.), but I realized we probably don't want to add that to dcrdocs until there's an official release of Decrediton that supports LN. We could start adding more technical details in a new page under '/Advanced', but a page under '/Wallets' should be more end user oriented. 

I'm tempted to say let's hold off on this page until there's something a user can use without having to compile from source, but it's also awkward that we're promoting our Lightning launch and don't have it in the docs at all. Thoughts? 