### PR TITLE
Add explanation hard cap inflation page

### DIFF
--- a/docs/advanced/inflation.md
+++ b/docs/advanced/inflation.md
@@ -16,6 +16,8 @@ If a block includes less than 5 PoS votes there will be a fraction of the block 
 
 > The last block reward will be created in September 2120. The upper limit on the total supply of Decred is 20,999,999.99800912 coins[^2].
 
+The hard cap with no “tail emissions” beyond the scheduled ~21M is designed to provide certainty in the monetary policy and prevent existing holders from being diluted by future manipulation of the monetary supply.
+
 The following chart shows an estimate of the coin supply growth over time.
 
 ![Decred supply chart](/img/decred_supply.png)


### PR DESCRIPTION
Per this [discussion](https://matrix.to/#/!MgQoetFiyjrHAywokv:decred.org/$15668471348365WoNgw:decred.org?via=decred.org&via=matrix.org&via=zettaport.com), we want to explain the ~21M hard cap.

This PR adds a short explanation of the hard cap design decision to the Inflation page ( Closes #975 ). 
