### PR TITLE
Add Decred Medium page to social links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ extra:
       link: 'https://github.com/decred'
     - type: 'twitter'
       link: 'https://twitter.com/decredproject'
+    - type: 'medium'
+      link: 'https://medium.com/decred'
     - type: 'reddit'
       link: 'https://www.reddit.com/r/decred/'
     - type: 'youtube'


### PR DESCRIPTION
Decred's Medium page is an important source of information when it comes to Decred knowledge. It should be referenced from Decred documentation.