### PR TITLE
Remove font-weight:bold from fa icons

### DIFF
--- a/docs/css/fonts.css
+++ b/docs/css/fonts.css
@@ -104,8 +104,14 @@ pre, code {
     font-size: 16px;
 }
 
+
 .md-typeset a {
     font-weight: bold;
+}
+/* We want all links to be bold, but not if they contain
+font-awesome icons */
+a.fa{
+    font-weight: normal;
 }
 .md-typeset a:link,
 .md-typeset a:visited {


### PR DESCRIPTION
Social links at the bottom of every page are made pretty with font-awesome icons. They are currently bolded, which makes them look weird.