### PR TITLE
Specify proposal amounts in USD

### DIFF
--- a/docs/governance/politeia/example-proposals.md
+++ b/docs/governance/politeia/example-proposals.md
@@ -53,7 +53,7 @@ complete the work, and who will draw down on the proposal's budget.
 ### When
 
 In the *When* section, describe the project's milestones, expected 
-completion dates, and the draw schedule (how much DCR is paid for each milestone delivered).
+completion dates, and the draw schedule (how much is paid for each milestone delivered).
 
 > We are proposing doing the design and documentation first, then finish the work with the implementation of the code.
 > We allow for some time between the deliverables in order for the community to provide feedback on the initial design and 
@@ -134,7 +134,7 @@ complete the work, and who will draw down on the proposal's budget.
 ### When
 
 In the *When* section, describe the project's milestones, expected 
-completion dates, and the draw schedule (how much DCR is paid for each milestone delivered).
+completion dates, and the draw schedule (how much is paid for each milestone delivered).
 
 > Registration fees are due by September 30th, I will pay these up-front and request full reimbursement immediately.
 > I will front the cost of the swag and Stakey suit, and claim this along with my travel/accommodation expenses and payment for my work, after the event.

--- a/docs/governance/politeia/proposal-guidelines.md
+++ b/docs/governance/politeia/proposal-guidelines.md
@@ -16,7 +16,7 @@ in the [proposal template](#proposal-template), your proposal should provide the
 information (if applicable).
 
 * **Total budget:** If your proposal draws down on its budget when milestones are achieved,
-include a draw schedule (how much DCR is paid for each milestone achieved).
+include a draw schedule (how much is paid for each milestone achieved). To account for variance in the price of DCR, amounts should be specified in USD. The amount of DCR distributed will then be adjusted at payout according to the exchange rate.
 * **Duration of contract:** If your proposal provides an ongoing service, your proposal must
 provide an end date.
 * **Restrictions on deliverables:** Specify any license or other restrictions on
@@ -55,7 +55,7 @@ complete the work and draw down on the proposal's budget.
 ### When
 
 In the *When* section, describe the project's milestones, expected
-completion dates, and the draw schedule (how much DCR is paid for each milestone achieved).
+completion dates, and the draw schedule (how much is paid for each milestone achieved).
 
 ---
 


### PR DESCRIPTION
Updates the proposal guidelines and example proposal pages to specify that payment amounts must be in USD ( Closes #982 ).