### PR TITLE
Adds warning scam airdrops

### DIFF
--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -22,7 +22,7 @@ When Decred launched in February 2016, the developers and project members commit
 
 
 !!! warning "Warning"
-    Decred is not currently running an airdrop! The only airdrop Decred has ever conducted was at launch, as described below. Offers to airdrop DCR are likely scams.  
+    Decred is not currently running an airdrop! Offers to airdrop DCR are likely scams. The only airdrop Decred has ever conducted was at launch, as described below.
 
 In total, **840,000 coins** (**50% of premine**, **4% of total Decred supply**), were distributed evenly across a list of airdrop participants. 
 

--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -20,6 +20,10 @@ When Decred launched in February 2016, the developers and project members commit
 
 ## Airdrop
 
+
+!!! warning "Warning"
+    Decred is not currently running an airdrop! The only airdrop Decred has ever conducted was at launch, as described below. Offers to airdrop DCR are likely scams.  
+
 In total, **840,000 coins** (**50% of premine**, **4% of total Decred supply**), were distributed evenly across a list of airdrop participants. 
 
 Sign-up for the airdrop opened with a public announcement on December 15th, 2015 and closed on January 18th, 2016. Not all participants who signed up were selected to participate in the airdrop - Decred is fundamentally about technological progress, so the airdrop targeted individuals that have made contributions towards advancing technology in its various forms. There were also a large number of fraudulent sign-ups, which were carefully identified and dealt with.


### PR DESCRIPTION
Per @degeri's [comment](https://matrix.to/#/!tfqymymiNgzSUJTHqS:decred.org/$157632331763516GZMwK:decred.org?via=decred.org&via=matrix.org&via=zettaport.com) in #Documentation, scammers sometimes promote fake airdrops to steal DCR. This PR adds a warning to the premine page warning users about this. 

![image](https://user-images.githubusercontent.com/1634777/70853302-f7b8d280-1e60-11ea-9f39-f0a0ac0198eb.png)

