### PR TITLE
Update deps.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM python:3.7
+FROM python:3.8
 
 LABEL description="dcrdocs build"
 LABEL version="1.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+# We need to fix markdown at version 3.1.1 because version 3.2 has been released but it is not supported by mkdocs-material yet.
+# This can be removed next time we update the mkdocs-material version.
+markdown==3.1.1
 mkdocs==1.0.4
-mkdocs-material==4.5.0
+mkdocs-material==4.6.0
 mkdocs-markdownextradata-plugin==0.1.1
 fontawesome-markdown==0.2.6


### PR DESCRIPTION
We need to fix markdown at version 3.1.1 because version 3.2 has been released but it is not supported by mkdocs-material yet. This can be removed next time we update the mkdocs-material version.