### PR TITLE
Add Redeem Script page

### DIFF
--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -59,6 +59,20 @@ In the unlikely scenario your VSP goes down permanently, you can still vote your
 
 ---
 
+#### 9. My VSP went down and I lost the redeem script, is there a way to recover it?
+
+Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred's block explorer, dcrdata.
+
+1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
+
+2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the ASM scripSig, a long string separated by a white space.
+
+3. Grab the second part of the ASM scriptSig, this is your redeem script.
+
+4. Import the script into your wallet to vote or revoke your tickets as usual.
+
+---
+
 ## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources 
 
 [^9262]: Decred Forum, [Post 9,262](https://forum.decred.org/threads/626/#post-9262)

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -65,7 +65,7 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 
 1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scripSig`. It can be found inside the `vin` key.
+2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scriptSig`. It can be found inside the `vin` key.
 
 3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -65,9 +65,9 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 
 1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the ASM scripSig, a long string separated by a white space.
+2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scripSig`. It can be found inside the `vin` key.
 
-3. Grab the second part of the ASM scriptSig, this is your redeem script.
+3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
 4. Import the script into your wallet to vote or revoke your tickets as usual.
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -61,7 +61,7 @@ In the unlikely scenario your VSP goes down permanently, you can still vote your
 
 #### 9. My VSP went down and I lost the redeem script, is there a way to recover it?
 
-When a ticket votes or is revoked, that redeem script is revealed as a part of the process. Redeem scripts that have been used at least once to vote or revoke a ticket can be [recovered using Decred's block explorer](/proof-of-stake/redeem-script/#recovery-methods).
+When a ticket votes or is revoked, that redeem script is revealed as a part of the process. Redeem scripts that have been used at least once to vote or revoke a ticket can be [recovered using Decred's block explorer](../../proof-of-stake/redeem-script.md#recovery-methods).
 
 ---
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -61,15 +61,7 @@ In the unlikely scenario your VSP goes down permanently, you can still vote your
 
 #### 9. My VSP went down and I lost the redeem script, is there a way to recover it?
 
-Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred's block explorer, dcrdata.
-
-1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
-
-2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scriptSig`. It can be found inside the `vin` key.
-
-3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
-
-4. Import the script into your wallet to vote or revoke your tickets as usual.
+When a ticket votes or is revoked, that redeem script is revealed as a part of the process. Redeem scripts that have been used at least once to vote or revoke a ticket can be [recovered using Decred's block explorer](/proof-of-stake/redeem-script/#recovery-methods).
 
 ---
 

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -24,9 +24,9 @@ A list of Voting Service Providers (VSPs) and statistics is maintained on the
 Using a VSP **does not give the VSP access to your funds**. All you are doing is granting voting rights to the VSP.
 
 !!! warning "Warning"
-    When using a VSP, remember to [backup your redeem script](../../wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
+    {{ scriptWarning1 }}
 
-    Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script/#recovery-methods).
+    {{ scriptWarning2 }}
 
 In order to support network decentralization, it is recommended that you join a smaller VSP with fewer live tickets. As VSPs control tickets delegated to them, they could in theory vote those tickets in a way which contradicts the expressed wishes of the ticket owners. This could be easily detected, and any VSP which attempted it would likely be abandoned by the stakeholder community. However, it is good practice to limit the power of individual VSPs, to limit the potential for damage from this kind of attack.
 

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -23,6 +23,11 @@ A list of Voting Service Providers (VSPs) and statistics is maintained on the
 
 Using a VSP **does not give the VSP access to your funds**. All you are doing is granting voting rights to the VSP.
 
+!!! warning "Warning"
+    When using a VSP, remember to [backup your redeem script](../../wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
+
+    Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-redeem-script-is-there-a-way-to-recover-it).
+
 In order to support network decentralization, it is recommended that you join a smaller VSP with fewer live tickets. As VSPs control tickets delegated to them, they could in theory vote those tickets in a way which contradicts the expressed wishes of the ticket owners. This could be easily detected, and any VSP which attempted it would likely be abandoned by the stakeholder community. However, it is good practice to limit the power of individual VSPs, to limit the potential for damage from this kind of attack.
 
 Unlike Proof-of-Work (PoW) mining pools, VSPs do not pool work or rewards. The number of tickets a VSP has does not affect how regularly one's tickets will be called and rewards received. 

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -26,7 +26,7 @@ Using a VSP **does not give the VSP access to your funds**. All you are doing is
 !!! warning "Warning"
     When using a VSP, remember to [backup your redeem script](../../wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
 
-    Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-redeem-script-is-there-a-way-to-recover-it).
+    Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script/#recovery-methods).
 
 In order to support network decentralization, it is recommended that you join a smaller VSP with fewer live tickets. As VSPs control tickets delegated to them, they could in theory vote those tickets in a way which contradicts the expressed wishes of the ticket owners. This could be easily detected, and any VSP which attempted it would likely be abandoned by the stakeholder community. However, it is good practice to limit the power of individual VSPs, to limit the potential for damage from this kind of attack.
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -2,7 +2,7 @@
 
 ---
 
-When users sign up with a VSP, both the user and the VSP jointly create a 1-of-2 multisignatura script. This script is known as the redeem script.
+When users sign up with a VSP, both the user and the VSP jointly create a 1-of-2 multisignature script. This script is known as the redeem script.
 
 The redeem script involves both a public key from the user and a public key from the VSP so that both can vote and revoke the ticket. When the user buys a new ticket, the voting rights are given to a hash of that redeem script.
 
@@ -14,15 +14,13 @@ At first, when the user just signs up, the redeem script is not known by anyone 
 
 The VSP handles voting and revoking for the user, but if it goes offline is up to the user to vote or revoke, which means the wallet needs to know the redeem script.
 
-Currently, users can't reconstruct these scripts from their own seed, this is why users must backup their redeem scripts to ensure they don't end up with locked funds due to the VSP going offline.
+Currently, users can't reconstruct these scripts from their own seed, this is why they must [backup their redeem scripts](/wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 
 ---
 
 ## What happens if the script is lost?
 
-User who purchased a ticket through a VSP that is no longer available and lost their redeem scripts won't be able to vote or revoke their tickets. This means their funds will remain locked.
-
-This is why users must back up their redeem script as soon as they sign up with a VSP and store it in a safe place.
+User who purchased a ticket through a VSP that is no longer available and lost their redeem script won't be able to vote or revoke their tickets. This means their funds will remain locked.
 
 ---
 
@@ -32,7 +30,7 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 
 1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scripSig`. It can be found inside the `vin` key.
+2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scriptSig`. It can be found inside the `vin` key.
 
 3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -2,7 +2,7 @@
 
 ---
 
-When users sign up with a VSP, both the user and the VSP jointly create a 1-of-2 multisignature script. This script is known as the redeem script.
+When users sign up with a [Voting Service Provider](/glossary/#voting-service-provider) (VSP), both the user and the VSP jointly create a 1-of-2 multisignature script. This script is known as the redeem script.
 
 The redeem script involves both a public key from the user and a public key from the VSP so that both can vote and revoke the ticket. When the user buys a new ticket, the voting rights are given to a hash of that redeem script.
 
@@ -12,27 +12,28 @@ The redeem script involves both a public key from the user and a public key from
 
 At first, when the user just signs up, the redeem script is not known by anyone except the user and the VSP. When the ticket votes or is revoked, that redeem script is revealed as a part of the process.
 
-The VSP handles voting and revoking for the user, but if it goes offline is up to the user to vote or revoke, which means the wallet needs to know the redeem script.
+The VSP handles voting and revoking for the user, but if it goes offline it is up to the user to vote or revoke the tickets, which means the wallet needs to know the redeem script.
 
-Currently, users can't reconstruct these scripts from their own seed, this is why they must [backup their redeem scripts](/wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
+Currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](/wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 
 ---
 
 ## What happens if the script is lost?
 
-User who purchased a ticket through a VSP that is no longer available and lost their redeem script won't be able to vote or revoke their tickets. This means their funds will remain locked.
+A user who purchased a ticket through a VSP that is no longer available and lost their redeem script won't be able to vote or revoke their tickets. This means their funds will remain locked.
 
 ---
 
 ## Recovery methods
 
-Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred’s block explorer, [dcrdata](https://explorer.dcrdata.org).
+Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred's block explorer, [dcrdata](https://dcrdata.org).
 
-1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
+1. Look for one of your vote or revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scriptSig`. It can be found inside the `vin` key.
+2. Search for the transaction using dcrdata. Once found, look under the 'Transaction Details' tab for the decoded JSON. Inside this JSON file, find the `scriptSig` in the `vin` key.
 
-3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
+3.  Under `scriptSig`, you should see a field for the `asm`, a deserialized form of the script. The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
 4. Import the script into your wallet to vote or revoke your tickets as usual.
+
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -12,7 +12,7 @@ When a VSP user buys a new ticket, the voting rights are given to a hash of the 
 
 At first, when a user has just signed up to a VSP, the redeem script is not known by anyone except the user and the VSP. When a ticket votes or is revoked, that redeem script is revealed on-chain as a part of the process.
 
-The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote using the remaining active tickets or revoke those that have expired. In order to do this, the users wallet also needs to know the redeem script.
+The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote the remaining active tickets or revoke those that have expired. In order to do this, the users wallet also needs to know the redeem script.
 
 When registering with a VSP, the user wallet will automatically store a copy of the redeem script, but currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](../wallets/decrediton/using-decrediton.md#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 
@@ -44,5 +44,4 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 1.  Under `scriptSig`, you should see a field for the `asm`, a deserialized form of the script. The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
 1. Import the script into your wallet to vote or revoke your tickets as usual.
-
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -2,9 +2,9 @@
 
 ---
 
-When users sign up with a [Voting Service Provider](/glossary/#voting-service-provider) (VSP), both the user and the VSP jointly create a 1-of-2 multisignature script. This script is known as the redeem script.
+When users sign up with a [Voting Service Provider](../glossary.md#voting-service-provider) (VSP), both the user and the VSP jointly create a 1-of-2 multisignature script. This script is known as the redeem script.
 
-The redeem script involves both a public key from the user and a public key from the VSP so that both can vote and revoke the ticket. When the user buys a new ticket, the voting rights are given to a hash of that redeem script.
+When a VSP user buys a new ticket, the voting rights are given to a hash of the redeem script. The redeem script involves both a public key from the user and a public key from the VSP, so either are able to vote or revoke the purchased tickets.
 
 ---
 
@@ -12,15 +12,24 @@ The redeem script involves both a public key from the user and a public key from
 
 At first, when the user just signs up, the redeem script is not known by anyone except the user and the VSP. When the ticket votes or is revoked, that redeem script is revealed as a part of the process.
 
-The VSP handles voting and revoking for the user, but if it goes offline it is up to the user to vote or revoke the tickets, which means the wallet needs to know the redeem script.
+The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote using the remaining active tickets or revoke those that have expired. In order to do this, the user's wallet needs to know the redeem script.
 
-Currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](/wallets/decrediton/using-decrediton/#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
+When registering with a VSP, the user wallet will automatically store a copy of the redeem script, but currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](../wallets/decrediton/using-decrediton.md#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 
 ---
 
 ## What happens if the script is lost?
 
-A user who purchased a ticket through a VSP that is no longer available and lost their redeem script won't be able to vote or revoke their tickets. This means their funds will remain locked.
+A user who purchased a ticket through a VSP that is no longer available and lost their redeem script won't be able to vote or revoke their tickets.
+
+Users risk having their funds locked if the following conditions are met:
+
+- The user has not backed up their redeem script as the documentation and software instructs
+- The user lost all access to their existing wallet
+- The user has not backed up their wallet (or underlying wallet.db) that knows the script
+- The VSP went offline before ever voting or revoking a ticket with that redeem script
+- The user's wallet has been offline during that entire period to have not voted or revoked a ticket with that redeem script
+- The VSP operator is unresponsive to requests for the copy of the redeem script
 
 ---
 
@@ -30,10 +39,10 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 
 1. Look for one of your vote or revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Search for the transaction using dcrdata. Once found, look under the 'Transaction Details' tab for the decoded JSON. Inside this JSON file, find the `scriptSig` in the `vin` key.
+1. Search for the transaction using dcrdata. Once found, look under the 'Transaction Details' tab for the decoded JSON. Inside this JSON file, find the `scriptSig` in the `vin` key.
 
-3.  Under `scriptSig`, you should see a field for the `asm`, a deserialized form of the script. The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
+1.  Under `scriptSig`, you should see a field for the `asm`, a deserialized form of the script. The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
-4. Import the script into your wallet to vote or revoke your tickets as usual.
+1. Import the script into your wallet to vote or revoke your tickets as usual.
 
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -14,7 +14,7 @@ At first, when a user has just signed up to a VSP, the redeem script is not know
 
 The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote the remaining active tickets or revoke those that have expired. In order to do this, the users wallet also needs to know the redeem script.
 
-When registering with a VSP, the user wallet will automatically store a copy of the redeem script, but currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](../wallets/decrediton/using-decrediton.md#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
+When registering with a VSP, the users wallet will automatically store a copy of the redeem script, but currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](../wallets/decrediton/using-decrediton.md#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 
 ---
 
@@ -24,7 +24,7 @@ A user who purchased a ticket through a VSP that is no longer available and lost
 
 Users risk having their funds locked if the following conditions are met:
 
-- The user has not backed up their redeem script as the documentation and software instructs
+- The user has not backed up their redeem script
 - The user lost all access to their existing wallet
 - The user has not backed up their wallet (or underlying wallet.db) that knows the script
 - The VSP went offline before ever voting or revoking a ticket with that redeem script
@@ -44,4 +44,3 @@ Only redeem scripts that have been used at least once to vote or revoke a ticket
 1.  Under `scriptSig`, you should see a field for the `asm`, a deserialized form of the script. The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
 1. Import the script into your wallet to vote or revoke your tickets as usual.
-

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -10,9 +10,9 @@ When a VSP user buys a new ticket, the voting rights are given to a hash of the 
 
 ## Why users must backup their scripts
 
-At first, when the user just signs up, the redeem script is not known by anyone except the user and the VSP. When the ticket votes or is revoked, that redeem script is revealed as a part of the process.
+At first, when a user has just signed up to a VSP, the redeem script is not known by anyone except the user and the VSP. When a ticket votes or is revoked, that redeem script is revealed on-chain as a part of the process.
 
-The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote using the remaining active tickets or revoke those that have expired. In order to do this, the user's wallet needs to know the redeem script.
+The VSP handles voting and revoking for the user, but if it goes offline, it is up to the user to vote using the remaining active tickets or revoke those that have expired. In order to do this, the users wallet also needs to know the redeem script.
 
 When registering with a VSP, the user wallet will automatically store a copy of the redeem script, but currently, users can't reconstruct these scripts from their own seed. This is why they must [backup their redeem scripts](../wallets/decrediton/using-decrediton.md#backup-redeem-script) to ensure they don't end up with locked funds due to the VSP going offline.
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -28,13 +28,13 @@ This is why users must back up their redeem script as soon as they sign up with 
 
 ## Recovery methods
 
-Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred’s [block explorer](https://explorer.dcrdata.org), dcrdata.
+Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred’s block explorer, [dcrdata](https://explorer.dcrdata.org).
 
 1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
 
-2. Open the transaction using dcrdata and look into the decoded JSON to find the ASM scripSig, a long string separated by a white space.
+2. Open the transaction using [dcrdata](https://dcrdata.org) and look into the decoded JSON to find the `scripSig`. It can be found inside the `vin` key.
 
-3. Grab the second part of the ASM scriptSig, this is your redeem script.
+3.  The `asm` value should be a long string separated by a white space. Grab the second part of the `scriptSig` `asm`, this is your redeem script.
 
 4. Import the script into your wallet to vote or revoke your tickets as usual.
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -1,0 +1,40 @@
+# <img class="dcr-icon" src="/img/dcr-icons/QuestionTicket.svg" /> Redeem Script
+
+---
+
+When users sign up with a VSP, both the user and the VSP jointly create a 1-of-2 multisignatura script. This script is known as the redeem script.
+
+The redeem script involves both a public key from the user and a public key from the VSP so that both can vote and revoke the ticket. When the user buys a new ticket, the voting rights are given to a hash of that redeem script.
+
+---
+
+## Why users must backup their scripts
+
+At first, when the user just signs up, the redeem script is not known by anyone except the user and the VSP. When the ticket votes or is revoked, that redeem script is revealed as a part of the process.
+
+The VSP handles voting and revoking for the user, but if it goes offline is up to the user to vote or revoke, which means the wallet needs to know the redeem script.
+
+Currently, users can't reconstruct these scripts from their own seed, this is why users must backup their redeem scripts to ensure they don't end up with locked funds due to the VSP going offline.
+
+---
+
+## What happens if the script is lost?
+
+User who purchased a ticket through a VSP that is no longer available and lost their redeem scripts won't be able to vote or revoke their tickets. This means their funds will remain locked.
+
+This is why users must back up their redeem script as soon as they sign up with a VSP and store it in a safe place.
+
+---
+
+## Recovery methods
+
+Only redeem scripts that have been used at least once to vote or revoke a ticket can be recovered. If this is your case, you can find it using Decred’s [block explorer](https://explorer.dcrdata.org), dcrdata.
+
+1. Look for one of your vote o revoke transactions. This can be done creating a new wallet using your seed phrase, and checking your past tickets.
+
+2. Open the transaction using dcrdata and look into the decoded JSON to find the ASM scripSig, a long string separated by a white space.
+
+3. Grab the second part of the ASM scriptSig, this is your redeem script.
+
+4. Import the script into your wallet to vote or revoke your tickets as usual.
+

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -108,9 +108,9 @@ The total number of tickets you currently own is at the top of the page:
 Now is a good time to back up your VSPs multi-sig voting script (or "redeem script"). 
 
 !!! warning "Warning"
-    Only you and your VSP know the [redeem script](../../proof-of-stake/redeem-script.md). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
+    {{ scriptWarning1 }}
 
-    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script/#recovery-methods).
+    {{ scriptWarning2 }}
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -110,7 +110,7 @@ Now is a good time to back up your VSPs multi-sig voting script (or "redeem scri
 !!! warning "Warning"
     Only you and your VSP know the [redeem script](../../proof-of-stake/redeem-script.md). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
 
-    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-the-redeem-script-is-there-a-way-to-recover-it).
+    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script/#recovery-methods).
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -110,7 +110,7 @@ Now is a good time to back up your VSPs multi-sig voting script (or "redeem scri
 !!! warning "Warning"
     Only you and your VSP know the [redeem script](../../proof-of-stake/redeem-script.md). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
 
-    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-redeem-script-is-there-a-way-to-recover-it.
+    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-the-redeem-script-is-there-a-way-to-recover-it).
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -108,7 +108,9 @@ The total number of tickets you currently own is at the top of the page:
 Now is a good time to back up your VSPs multi-sig voting script (or "redeem script"). 
 
 !!! warning "Warning"
-    If your VSP goes down, you'll need this script to vote or revoke tickets.
+    Only you and your VSP know the [redeem script](../../proof-of-stake/redeem-script.md). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets.
+
+    Lost scripts which have been used at least one time to vote or revoke tickets [can be recovered](/faq/proof-of-stake/voting-service-providers/#9-my-vsp-went-down-and-i-lost-redeem-script-is-there-a-way-to-recover-it.
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ extra:
   seedWarning4:
     "**DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO ANYONE! NOT EVEN DECRED DEVELOPERS!**"
   scriptWarning1:
-    "Only you and your VSP know the [redeem script](/proof-of-stake/redeem-script). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets."
+    "When you register with a VSP, it is essential to backup your "[redeem script](/proof-of-stake/redeem-script)". Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets."
   scriptWarning2:
     "Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script#recovery-methods)."
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ extra:
   seedWarning4:
     "**DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO ANYONE! NOT EVEN DECRED DEVELOPERS!**"
   scriptWarning1:
-    "When you register with a VSP, it is essential to backup your "[redeem script](/proof-of-stake/redeem-script)". Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets."
+    " When you register with a VSP, it is essential to backup your "[redeem script](/proof-of-stake/redeem-script)". Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets. "
   scriptWarning2:
     "Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script#recovery-methods)."
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ extra:
   seedWarning4:
     "**DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO ANYONE! NOT EVEN DECRED DEVELOPERS!**"
   scriptWarning1:
-    " When you register with a VSP, it is essential to backup your "[redeem script](/proof-of-stake/redeem-script)". Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets. "
+    "When you register with a VSP, it is essential to backup your \u0022[redeem script](/proof-of-stake/redeem-script)\u0022. Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets."
   scriptWarning2:
     "Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script#recovery-methods)."
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
 - Proof-of-Stake Voting:
   - "Overview": 'proof-of-stake/overview.md'
   - "How to Stake": 'proof-of-stake/how-to-stake.md'
+  - "Redeem Script": 'proof-of-stake/redeem-script.md'
   - "Ticket Splitting": 'proof-of-stake/ticket-splitting.md'
 - Proof-of-Work Mining:
   - 'Overview': 'mining/overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,10 @@ extra:
     "Every seed phrase is also associated with a 64 character seed hex. The seed hex functions the same way as the seed phrase, so it is also important to keep your seed hex secure."
   seedWarning4:
     "**DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO ANYONE! NOT EVEN DECRED DEVELOPERS!**"
+  scriptWarning1:
+    "Only you and your VSP know the [redeem script](/proof-of-stake/redeem-script). You must backup the script to ensure you don't end up with locked funds. If your VSP goes down, you'll need this script to vote or revoke tickets."
+  scriptWarning2:
+    "Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script#recovery-methods)."
   social:
     - type: 'github'
       link: 'https://github.com/decred'


### PR DESCRIPTION
First draft to solve #1065

- Added new Redeem Script page under Proof-of-Stake
- Updated Using Decrediton "Backup redeem script" warning to state the risks
- Added a similar warning to the PoS/How to Stake page
- Added "9. My VSP went down and I lost the redeem script, is there a way to recover it?" to the FAQ under PoS/VSP.

Added the new page under Proof-of-Stake, it is a much more visible place than the FAQ, but it could be moved to the FAQ if we want to keep the Proof-of-Stake section clean of specific solo/vsp info.