### PR TITLE
multi: encourage users to verify binaries

### DIFF
--- a/docs/advanced/full-node.md
+++ b/docs/advanced/full-node.md
@@ -46,7 +46,7 @@ Below are some guides from the community that walk you step-by-step through sett
 
 Below are the basic high-level steps to install a full node on any hardware and OS. These instructions use [dcrinstall](../wallets/cli/cli-installation.md), the automatic installer and upgrader software. In addition to installing `dcrd`, it will also install `dcrwallet` (which allows you to create wallets) and `dcrctl` (which allows you to control `dcrwallet` and `dcrd` from the command line). You can also just install `dcrd` on its own from [binaries or source files](https://github.com/decred/dcrd#installing-and-updating); a full node does not require a wallet unless you want to use your full node to validate and broadcast your own transactions.
 
-1. **Download and install dcrd**
+1. **Download, verify, and install dcrd**
         - Follow the instructions for your OS in the [CLI Installation guide](../wallets/cli/cli-installation.md). The `dcrd` executable will be installed in a directory named `/decred` under your OS's home directory.
 1. **Start `dcrd`**
         - Navigate to the `/decred` directory and launch `dcrd`. See the [Operating System Differences](../wallets/cli/os-differences.md) page for OS-specific commands.

--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -19,7 +19,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | 32-bit       | `decred-windows-386-v{{ cliversion }}.zip`   |
         | 64-bit       | `decred-windows-amd64-v{{ cliversion }}.zip` |
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](verifying-binaries.md).
 
     1. Navigate to download location and extract the `.zip` file:
 
@@ -33,7 +33,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | ------------ | ---------------------------------------------- |
         | 64-bit       | `decred-darwin-amd64-v{{ cliversion }}.tar.gz` |
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](verifying-binaries.md).
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
@@ -58,7 +58,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | 32-bit ARM   | `decred-linux-arm-v{{ cliversion }}.tar.gz`   |
         | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion }}.tar.gz` |
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](verifying-binaries.md).
 
     1. Navigate to download location and extract the `.tar.gz` file:
 

--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -19,6 +19,8 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | 32-bit       | `decred-windows-386-v{{ cliversion }}.zip`   |
         | 64-bit       | `decred-windows-amd64-v{{ cliversion }}.zip` |
 
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
     1. Navigate to download location and extract the `.zip` file:
 
         Right click on the `.zip` file, select "Extract All..." and a prompt should open asking for the directory to use. The default will extract the `.zip` to a folder with the same name. It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
@@ -30,6 +32,8 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | Architecture | Filename                                       |
         | ------------ | ---------------------------------------------- |
         | 64-bit       | `decred-darwin-amd64-v{{ cliversion }}.tar.gz` |
+
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
 
     1. Navigate to download location and extract the `.tar.gz` file:
 
@@ -53,6 +57,8 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | 64-bit       | `decred-linux-amd64-v{{ cliversion }}.tar.gz` |
         | 32-bit ARM   | `decred-linux-arm-v{{ cliversion }}.tar.gz`   |
         | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion }}.tar.gz` |
+
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
 
     1. Navigate to download location and extract the `.tar.gz` file:
 

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -14,7 +14,7 @@ Last updated for CLI release v{{ cliversion }}.
 
     1. Download the `dcrinstall-darwin-amd64-v{{ cliversion }}` file. (32 bit builds for macOS are not available):
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
     1. Make `dcrinstall-darwin-amd64-v{{ cliversion }}` an executable within your terminal, and run it:
 
@@ -40,7 +40,7 @@ Last updated for CLI release v{{ cliversion }}.
 
         For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion }}` file.
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
     1. Make the downloaded file an executable within your terminal and run it:
 
@@ -62,7 +62,7 @@ Last updated for CLI release v{{ cliversion }}.
 
         For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion }}.exe` file.
 
-    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
     1. Run the dcrinstall executable file. You can either double click it or run it from the Command Prompt.
 

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -14,6 +14,8 @@ Last updated for CLI release v{{ cliversion }}.
 
     1. Download the `dcrinstall-darwin-amd64-v{{ cliversion }}` file. (32 bit builds for macOS are not available):
 
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
     1. Make `dcrinstall-darwin-amd64-v{{ cliversion }}` an executable within your terminal, and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run `chmod` with `u+x` mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
@@ -38,6 +40,8 @@ Last updated for CLI release v{{ cliversion }}.
 
         For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion }}` file.
 
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
     1. Make the downloaded file an executable within your terminal and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run `chmod` with `u+x` mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
@@ -58,6 +62,7 @@ Last updated for CLI release v{{ cliversion }}.
 
         For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion }}.exe` file.
 
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
 
     1. Run the dcrinstall executable file. You can either double click it or run it from the Command Prompt.
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -20,6 +20,16 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
     1. Download the Windows installer `decrediton-v{{ decreditonversion }}.exe`.
 
+        !!! Warning "Security Tip"
+        
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
+            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt`
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
+
     1. Double click the installer and follow the instructions.
 
     1. The installer adds a shortcut to Decrediton on your desktop.
@@ -28,6 +38,16 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
     1. Download the `decrediton-v{{ decreditonversion }}.dmg` file.
 
+        !!! Warning "Security Tip"
+        
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
+            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt`
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
+
     1. Double click the `decrediton-v{{ decreditonversion }}.dmg` file to mount the disk image.
 
     1. Drag the `decrediton.app` file into the link to your Applications folder within the disk image.
@@ -35,6 +55,16 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 ??? info "Linux instructions (click to expand)"
 
     1. Download the `decrediton-v{{ decreditonversion }}.tar.gz` file.
+
+        !!! Warning "Security Tip"
+        
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
+            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt`
+
+            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
 
     1. Navigate to the download location and extract `decrediton-v{{ decreditonversion }}.tar.gz`.
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -14,7 +14,7 @@ Last updated for Decrediton v{{ decreditonversion }}.
 
 ## Download and Install
 
-The latest version of Decrediton can be downloaded from <https://decred.org/downloads>.
+The latest version of Decrediton can be downloaded from <https://decred.org/wallets/>.
 
 ??? info "Windows instructions (click to expand)"
 
@@ -22,7 +22,7 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
         !!! Warning "Security Tip"
         
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
             You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
 
@@ -40,7 +40,7 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
         !!! Warning "Security Tip"
         
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
             You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
 
@@ -58,7 +58,7 @@ The latest version of Decrediton can be downloaded from <https://decred.org/down
 
         !!! Warning "Security Tip"
         
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
             You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
 

--- a/docs/wallets/decrediton/upgrading-decrediton.md
+++ b/docs/wallets/decrediton/upgrading-decrediton.md
@@ -6,7 +6,7 @@ To upgrade Decrediton, simply download the new version and install it. You do no
 
 ## Upgrading steps
 
-1. Download latest version. The latest downloads can be found at [https://decred.org/downloads/](https://decred.org/downloads/) or by clicking on the `Update Available` button in the upper right-hand corner of Decrediton.
+1. Download the latest version from [https://decred.org/wallets/](https://decred.org/wallets/) or by clicking on the `Update Available` button in the upper right-hand corner of Decrediton.
 
     ![Decrediton update link](/img/decrediton/upgrading/update-available.png)
 
@@ -16,7 +16,7 @@ To upgrade Decrediton, simply download the new version and install it. You do no
 
     !!! Warning "Security Tip"
     
-        We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+        We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
         You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
 

--- a/docs/wallets/decrediton/upgrading-decrediton.md
+++ b/docs/wallets/decrediton/upgrading-decrediton.md
@@ -14,6 +14,16 @@ To upgrade Decrediton, simply download the new version and install it. You do no
 
     ![Decrediton update link](/img/decrediton/upgrading/download-link.png)
 
+    !!! Warning "Security Tip"
+    
+        We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](https://docs.decred.org/advanced/verifying-binaries/).
+
+        You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
+
+        `decrediton-v{{ decreditonversion }}-manifest.txt`
+
+        `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
+
 1. Close your current version of Decrediton (if open) and click on the downloaded installer. Follow the installation instructions as you would for any other program. 
 1. Open Decrediton. Note that when upgrading, Decrediton may need to perform a one-time reindexing operation.  This can take several minutes to an hour depending on your hardware.
 1. Click on the `Governance` tab to check for new Politeia proposals and consensus rule changes. Upgraded versions of Decrediton may contain latent consensus rule changes that will be automatically enabled if stakeholders vote to accept them. For more on voting, see the governance section of the [Using Decrediton](../wallets/decrediton/using-decrediton/#governance) page. 


### PR DESCRIPTION
Since new users may be unfamiliar with the concept of verifying binaries, the following pages were updated to encourage users to follow good security practices:

advanced/full-node.md
advanced/manual-cli-install.md
wallets/cli/cli-installation.md
wallets/decrediton/decrediton-setup.md
wallets/decrediton/upgrading-decrediton.md

First-time Decrediton users will potentially be the most novice, and were only ever directed to Decred.org/downloads, so I tried to emphasize that verifying binaries is an *optional* security step by listing it inside step 1 in its own admonition block. I also added links to the manifest there.