### PR TITLE
FIXED 2 broken paths

### DIFF
--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -55,7 +55,7 @@ These mining pools are known to support Decred:
 * [:fontawesome-solid-external-link-square-alt: F2Pool](https://www.f2pool.com)
 * [:fontawesome-solid-external-link-square-alt: Poolin](https://www.poolin.com)
 * [:fontawesome-solid-external-link-square-alt: UUpool](https://uupool.cn/dcr)
-* [:fontawesome-solid-external-link-square-alt: Luxor](https://mining.luxor.tech/decred)
+* [:fontawesome-solid-external-link-square-alt: Luxor](https://mining.luxor.tech/coins/decred)
 * [:fontawesome-solid-external-link-square-alt: Coinmine](https://www2.coinmine.pl/dcr/)
 * [:fontawesome-solid-external-link-square-alt: Suprnova](https://dcr.suprnova.cc)
 

--- a/docs/privacy/general-privacy.md
+++ b/docs/privacy/general-privacy.md
@@ -50,7 +50,7 @@ may be able to link it to your public IP address.
 It is possible to route your dcrd traffic through Tor to mitigate this risk.
 Another solution is to broadcast your transaction through a public website,
 using Tor to provide anonymity.
-For example, [dcrdata](https://github.org/decred/dcrdata) has this
+For example, [dcrdata](https://github.com/decred/dcrdata) has this
 functionality, and is available as a hidden service on Tor using the URL
 <http://dcrdata2opeenddl.onion>.
 


### PR DESCRIPTION
Fix the path to 'Luxor' mining pool

* https://mining.luxor.tech/decred > https://mining.luxor.tech/coins/decred

Fix the path to 'Github'

* https://github.org/decred/dcrdata > https://github.com/decred/dcrdata