### PR TITLE
Use snippets plugin.

### DIFF
--- a/docs/advanced/solo-proof-of-stake-voting.md
+++ b/docs/advanced/solo-proof-of-stake-voting.md
@@ -62,15 +62,7 @@ Once your machine is set up you will need to install the Decred CLI tools.
 
     `echo "PATH=~/decred:$PATH" >> ~/.profile && source ~/.profile`
 
-!!! danger "Critical Information"
-
-    {{ seedWarning1 }}
-
-    {{ seedWarning2 }}
-
-    {{ seedWarning3 }}
-
-    {{ seedWarning4 }}
+--8<-- "seed-warning.md"
 
 ---
 

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -23,10 +23,7 @@ A list of Voting Service Providers (VSPs) and statistics is maintained on the
 
 Using a VSP **does not give the VSP access to your funds**. All you are doing is granting voting rights to the VSP.
 
-!!! warning "Warning"
-    {{ scriptWarning1 }}
-
-    {{ scriptWarning2 }}
+--8<-- "script-warning.md"
 
 In order to support network decentralization, it is recommended that you join a smaller VSP with fewer live tickets. As VSPs control tickets delegated to them, they could in theory vote those tickets in a way which contradicts the expressed wishes of the ticket owners. This could be easily detected, and any VSP which attempted it would likely be abandoned by the stakeholder community. However, it is good practice to limit the power of individual VSPs, to limit the potential for damage from this kind of attack.
 

--- a/docs/wallets/cli/dcrwallet-setup.md
+++ b/docs/wallets/cli/dcrwallet-setup.md
@@ -14,15 +14,7 @@ This guide is intended to help you setup the `dcrwallet` application using [star
 
 In order to run `dcrwallet`, a `wallet.db` must exist within `dcrwallet`'s home directory. In order for that file to exist, you must create a new wallet. `dcrinstall` automatically starts the creation process. If you delete your wallet.db or used another installation process, you'll have to run the [manual wallet creation command](#manual-wallet-creation-command).
 
-!!! danger "Critical Information"
-
-    {{ seedWarning1 }}
-
-    {{ seedWarning2 }}
-
-    {{ seedWarning3 }}
-
-    {{ seedWarning4 }}
+--8<-- "seed-warning.md"
 
 ---
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -117,15 +117,7 @@ You can begin to set up your wallet before the download completes. You have two 
 
 As Decrediton allows you to manage multiple wallets on one PC, you must give a name to your wallet so it can be identified. Enter a name and press the **Continue** button.
 
-!!! danger "Critical Information"
-
-    {{ seedWarning1 }}
-
-    {{ seedWarning2 }}
-
-    {{ seedWarning3 }}
-
-    {{ seedWarning4 }}
+--8<-- "seed-warning.md"
 
 The 33 word seed for your new wallet is displayed on the screen (obscured in the below image). Record the seed and store it somewhere safe.
 

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -107,10 +107,7 @@ The total number of tickets you currently own is at the top of the page:
 
 Now is a good time to back up your VSPs multi-sig voting script (or "redeem script"). 
 
-!!! warning "Warning"
-    {{ scriptWarning1 }}
-
-    {{ scriptWarning2 }}
+--8<-- "script-warning.md"
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,18 +13,6 @@ extra:
   cliversion: 1.5.2
   gominerversion: 1.0.0
   lndversion: 0.2.1
-  seedWarning1:
-    "During the creation process for your wallet, you will be given a sequence of 33 words known as a seed phrase. This seed phrase is essentially the private key for your wallet. You will be able to use this seed phrase to restore your private keys, transaction history, and balances using any Decred wallet on any computer."
-  seedWarning2:
-    "This ultimately means that *anyone* who knows your seed can use it to restore your private keys, transaction history, and balances to a Decred wallet on their computer without your knowledge. For this reason, it is of utmost importance to keep your seed phrase safe. Treat this seed the same way you would treat a physical key to a safe. If you lose your seed phrase, you permanently lose access to your wallet and all funds within it. It cannot be recovered by anyone, including the Decred developers. It is recommended you write it down on paper and store that somewhere secure. If you decide to keep it on your computer, it would be best to keep it in an encrypted document (do not forget the password) in case the file or your computer is stolen."
-  seedWarning3:
-    "Every seed phrase is also associated with a 64 character seed hex. The seed hex functions the same way as the seed phrase, so it is also important to keep your seed hex secure."
-  seedWarning4:
-    "**DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO ANYONE! NOT EVEN DECRED DEVELOPERS!**"
-  scriptWarning1:
-    "When you register with a VSP, it is essential to backup your \u0022[redeem script](/proof-of-stake/redeem-script)\u0022. Only you and your VSP know the redeem script, and it must be backed up to ensure you don't end up with locked funds. If your VSP goes down, you'll need the script to vote or revoke tickets."
-  scriptWarning2:
-    "Lost scripts which have been used at least once to vote or revoke tickets [can be recovered](/proof-of-stake/redeem-script#recovery-methods)."
   social:
     - icon: octicons/mark-github-16
       link: https://github.com/decred
@@ -51,6 +39,9 @@ markdown_extensions:
   - markdown.extensions.toc:
       permalink: True
   - markdown.extensions.tables
+  - pymdownx.snippets:
+      check_paths: True
+      base_path: 'snippets'
   - pymdownx.details
   - pymdownx.arithmatex
   - pymdownx.emoji:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.1.2
-mkdocs-material==5.5.8
-mkdocs-material-extensions==1.0
+mkdocs-material==5.5.14
+mkdocs-material-extensions==1.0.1
 mkdocs-markdownextradata-plugin==0.1.7

--- a/snippets/script-warning.md
+++ b/snippets/script-warning.md
@@ -1,0 +1,10 @@
+!!! warning "Warning"
+
+    When you register with a VSP, it is essential to backup your "[redeem
+    script](/proof-of-stake/redeem-script)". Only you and your VSP know the
+    redeem script, and it must be backed up to ensure you don't end up with
+    locked funds. If your VSP goes down, you'll need the script to vote or
+    revoke tickets.
+
+    Lost scripts which have been used at least once to vote or revoke tickets [can
+    be recovered](/proof-of-stake/redeem-script#recovery-methods).

--- a/snippets/seed-warning.md
+++ b/snippets/seed-warning.md
@@ -1,0 +1,25 @@
+!!! danger "Critical Information"
+
+    During the creation process for your wallet, you will be given a sequence of 33
+    words known as a seed phrase. This seed phrase is essentially the private key
+    for your wallet. You will be able to use this seed phrase to restore your
+    private keys, transaction history, and balances using any Decred wallet on any
+    computer.
+
+    This ultimately means that *anyone* who knows your seed can use it to restore
+    your private keys, transaction history, and balances to a Decred wallet on their
+    computer without your knowledge. For this reason, it is of utmost importance to
+    keep your seed phrase safe. Treat this seed the same way you would treat a
+    physical key to a safe. If you lose your seed phrase, you permanently lose
+    access to your wallet and all funds within it. It cannot be recovered by anyone,
+    including the Decred developers. It is recommended you write it down on paper
+    and store that somewhere secure. If you decide to keep it on your computer, it
+    would be best to keep it in an encrypted document (do not forget the password)
+    in case the file or your computer is stolen.
+
+    Every seed phrase is also associated with a 64 character seed hex. The seed hex
+    functions the same way as the seed phrase, so it is also important to keep your
+    seed hex secure.
+
+    **DO NOT, UNDER ANY CIRCUMSTANCES, GIVE YOUR SEED OR THE ASSOCIATED HEX KEY TO
+    ANYONE! NOT EVEN DECRED DEVELOPERS!**


### PR DESCRIPTION
Using the snippets plugin allows the removal of markdown formatted content from a .yml config file. This was always an abuse of the config file, and using the plugin is a more proper solution.