### PR TITLE
Use tabs for OS specific instructions.

### DIFF
--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -6,7 +6,7 @@ Last updated for CLI release v{{ cliversion }}.
 
 The newest binary releases can be found [here](https://github.com/decred/decred-binaries/releases). With the exception of the `.exe` and `.dmg` files, they are archives of the latest executable binaries for each release. Although most of this will be extract and go, instructions are provided for Windows, macOS, and Linux below.
 
-??? info "Windows instructions (click to expand)"
+=== "Windows"
 
     1. Download the correct file for your computer:
 
@@ -19,9 +19,9 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
     1. Navigate to download location and extract the `.zip` file:
 
-        Right click on the `.zip` file, select "Extract All..." and a prompt should open asking for the directory to use. The default will extract the `.zip` to a folder with the same name. It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Right click on the `.zip` file, select "Extract All..." and a prompt should open asking for the directory to use. The default will extract the `.zip` to a folder with the same name.
 
-??? info "macOS instructions (click to expand)"
+=== "macOS"
 
     1. Download the correct file for your computer:
 
@@ -37,13 +37,9 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion }}`).
 
-    !!! note
-
-        If you are using Safari on macOS Sierra and have the 'Open "safe" files after downloading' preference enabled, `.gz` and `.zip` files are automatically extracted after download. The `tar -xvzf filename.tar.gz` command results in this error: `tar: Error opening archive: Failed to open 'filename.tar.gz'`. Use `tar -xvzf filename.tar` instead (remove the `.gz` from the previous command).
-
-??? info "Linux instructions (click to expand)"
+=== "Linux"
 
     1. Download the correct file for your computer:
 
@@ -62,7 +58,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion }}`). It should include `dcrctl`, `dcrd`, `dcrwallet`, `sample-dcrctl.conf`, `sample-dcrd.conf`, and `sample-dcrwallet.conf`.
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion }}`).
 
 ---
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -101,3 +101,8 @@ details .md-typeset__table {
     border-radius: 3px;
     background-color: #EDEFF1;
 }
+
+.tabbed-set {
+    border-left: .2rem solid #536dfe;
+    box-shadow: 0 0.2rem 0.5rem rgba(0,0,0,.05), 0 0 0.05rem rgba(0,0,0,.1);
+}

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -10,7 +10,7 @@ Last updated for CLI release v{{ cliversion }}.
 
 `dcrinstall` will automatically download the precompiled, signed binary package found on GitHub, verify the signature of this package, copy the binaries within the package to a specific folder dependent on OS, create configuration files with settings to allow the 3 applications to communicate with each other, and run you through the wallet creation process. After running through `dcrinstall`, you will be able to launch the software with no additional configuration.
 
-??? info "macOS instructions (click to expand)"
+=== "macOS"
 
     1. Download the `dcrinstall-darwin-amd64-v{{ cliversion }}` file. (32 bit builds for macOS are not available):
 
@@ -28,7 +28,7 @@ Last updated for CLI release v{{ cliversion }}.
 
     1. The executable binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
-??? info "Linux instructions (click to expand)"
+=== "Linux"
 
     1. Download the correct file:
 
@@ -54,7 +54,7 @@ Last updated for CLI release v{{ cliversion }}.
 
     1. The binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
 
-??? info "Windows instructions (click to expand)"
+=== "Windows"
 
     1. Download the correct file:
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -16,55 +16,36 @@ Last updated for Decrediton v{{ decreditonversion }}.
 
 The latest version of Decrediton can be downloaded from <https://decred.org/wallets/>.
 
-??? info "Windows instructions (click to expand)"
+!!! Warning "Security Tip"
+
+    We recommend you also verify that your download hash matches the hash in the Decred releases manifest.
+    For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
+
+    You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
+
+    `decrediton-v{{ decreditonversion }}-manifest.txt`
+
+    `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
+
+=== "Windows"
 
     1. Download the Windows installer `decrediton-v{{ decreditonversion }}.exe`.
-
-        !!! Warning "Security Tip"
-        
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
-
-            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt`
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
 
     1. Double click the installer and follow the instructions.
 
     1. The installer adds a shortcut to Decrediton on your desktop.
 
-??? info "macOS instructions (click to expand)"
+=== "macOS"
 
     1. Download the `decrediton-v{{ decreditonversion }}.dmg` file.
-
-        !!! Warning "Security Tip"
-        
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
-
-            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt`
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
 
     1. Double click the `decrediton-v{{ decreditonversion }}.dmg` file to mount the disk image.
 
     1. Drag the `decrediton.app` file into the link to your Applications folder within the disk image.
 
-??? info "Linux instructions (click to expand)"
+=== "Linux"
 
     1. Download the `decrediton-v{{ decreditonversion }}.tar.gz` file.
-
-        !!! Warning "Security Tip"
-        
-            We recommend you also verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
-
-            You will need to visit the [Release Binaries](https://github.com/decred/decred-binaries/releases) page to download the manifest and manifest signature:
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt`
-
-            `decrediton-v{{ decreditonversion }}-manifest.txt.asc`
 
     1. Navigate to the download location and extract `decrediton-v{{ decreditonversion }}.tar.gz`.
 
@@ -73,7 +54,6 @@ The latest version of Decrediton can be downloaded from <https://decred.org/wall
     1. Open a terminal in the extracted folder and run the command `chmod u+x decrediton`.
     
     1. Decrediton can then be launched from the terminal using the command `./decrediton`.
-    
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,8 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.tabbed
+  - pymdownx.superfences
 extra_javascript:
   - js/MathJax-2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 extra_css:


### PR DESCRIPTION
This PR makes use of proper tabs for OS specific installation instructions rather than collapsable panels.

Also:
- Remove list of files which should be included in the release tar. Its unnecessary and prone to falling out of date (it already is).
- Remove overly specific edge case for installing on macOS Sierra
- Move a warning in decrediton-setup.md so it appears only once in source code, rather than three times.