### PR TITLE
Remove inline HTML for images

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Document.svg" /> License
+# ![](../img/dcr-icons/Document.svg){ .dcr-icon } License
 
 dcrdocs is licensed under the [copyfree](http://copyfree.org) ISC License.
 

--- a/docs/advanced/dcrtime.md
+++ b/docs/advanced/dcrtime.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> dcrtime
+# ![](../img/dcr-icons/Servers.svg){ .dcr-icon } dcrtime
 
 ---
 

--- a/docs/advanced/dcrtime.md
+++ b/docs/advanced/dcrtime.md
@@ -37,9 +37,9 @@ The dcrtime service is comprised of four components:
 * **dcrwallet:** A Decred wallet daemon.
 * **dcrd:** A full node implementation of Decred.
 
-The diagram below illustrates how the components are connected. 
+The diagram below illustrates how the components are connected.
 
-![dcrtime architecture](/img/dcrtime_architecture_diagram.png)
+![dcrtime architecture](../img/dcrtime_architecture_diagram.png)
 
 ## dcrtime implementation
 
@@ -100,7 +100,7 @@ Politeia commits user data (new proposals, edits, etc.) as needed to a public gi
 
 The diagram below provides a high-level diagram of the timestamping process.
 
-![dcrtime politeia](/img/dcrtime_politeia_diagram.png)
+![dcrtime politeia](../img/dcrtime_politeia_diagram.png)
 
 To illustrate, let's examine an anchor from a real proposal, the [Decred Bug Bounty Proposal: Phase 2](https://proposals.decred.org/proposals/073694ed82d34b2bfff51e35220e8052ad4060899b23bc25791a9383375cae70) proposal. This anchor hashes two commits to the blockchain. The first [commit](https://github.com/decred-proposals/mainnet/commit/9125d351db4a429681cd7158d2c17d62a2b47c4c) contains all vote data submitted in the last hour. The second [commit](https://github.com/decred-proposals/mainnet/commit/afcca3b205ab6ec749d26e1903414aa35acd9767) contains all comments submitted in the last hour. First, Politeia will submit an anchor commit, which appends an "Audit Trail Record" containing metadata to `anchor_audit_trail.txt`, as shown below.  
 

--- a/docs/advanced/deleting-your-wallet.md
+++ b/docs/advanced/deleting-your-wallet.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/DeleteWallet.svg" /> Deleting Your Wallet 
+# ![](../img/dcr-icons/DeleteWallet.svg){ .dcr-icon } Deleting Your Wallet 
 
 There are a few reasons you might need to delete your wallet.
 

--- a/docs/advanced/full-node.md
+++ b/docs/advanced/full-node.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/AtoB.svg" /> Running a Full Node
+# ![](../img/dcr-icons/AtoB.svg){ .dcr-icon } Running a Full Node
 
 ---
 

--- a/docs/advanced/general-security.md
+++ b/docs/advanced/general-security.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Harddrive.svg" /> Security
+# ![](../img/dcr-icons/Harddrive.svg){ .dcr-icon } Security
 
 This page provides a list of things you can do to improve your security when working with DCR, or cryptocurrencies more generally.
 

--- a/docs/advanced/issuance.md
+++ b/docs/advanced/issuance.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Rocket.svg" /> Issuance
+# ![](../img/dcr-icons/Rocket.svg){ .dcr-icon } Issuance
 
 ---
 
@@ -432,7 +432,7 @@ Block height | Estimated date     | Block reward (DCR) | PoW (DCR)    | PoS (DCR
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } Sources
 
 [^1]: [Blockchain parameters](https://devdocs.decred.org/developer-guides/blockchain-parameters/) 
 [^2]: GitHub, [decred/dcrd](https://github.com/decred/dcrd/blob/5076a00512a521cea3c51b443b50970804dbe712/blockchain/subsidy_test.go#L52-L54)

--- a/docs/advanced/issuance.md
+++ b/docs/advanced/issuance.md
@@ -20,7 +20,7 @@ The hard cap with no “tail emissions” beyond the scheduled ~21M is designed 
 
 The following chart shows an estimate of the coin supply growth over time.
 
-![Decred supply chart](/img/decred_supply.png)
+![Decred supply chart](../img/decred_supply.png)
 
 The table below shows the estimated block reward and estimated total supply of Decred up to block 2,457,600 in 2039. Note that the total supply of DCR at block 1 is 1,680,000 due to the [premine](premine.md). There was no block reward for proof-of-work miners in block 1, which allowed miners to voluntarily choose whether or not to accept the terms of the airdrop independent of a potential reward which could skew the incentive. PoS voting started at block 4,096[^3] therefore PoS rewards were not generated before that height.
 

--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> Manual CLI Installation
+# ![](../img/dcr-icons/Dcrtl.svg){ .dcr-icon } Manual CLI Installation
 
 Last updated for CLI release v{{ cliversion }}.
 

--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -10,7 +10,7 @@ For the purpose of this guide we'll be using this [previous proposal](https://pr
 
 Below is a screenshot of the root directory of the [decred-proposals/mainnet](https://github.com/decred-proposals/mainnet) repo.  
 
-![The root of the mainnet repository. * = proposal folders, A = anchoring data](/img/politeia/mainnet-pi-repo.png)
+![The root of the mainnet repository. * = proposal folders, A = anchoring data](../img/politeia/mainnet-pi-repo.png)
 
 Folders marked with `*` contain proposal data. Folders and files marked with `A` contain anchoring data. Anchoring data relates to the anchoring of Politeia data to the Decred blockchain through [dcrtime](dcrtime.md), which facilitates Politeia's transparent censorship functionality. This guide will not describe those files in detail, as they are not likely to be of interest for analysis. 
 
@@ -18,11 +18,11 @@ Within each proposal folder there are sequentially numbered sub-folders, one for
 
 Below shows the contents of our example proposal's folder. As we can see, there are two versions of the proposal. 
 
-![Versions of the example proposal](/img/politeia/example-proposal.png)
+![Versions of the example proposal](../img/politeia/example-proposal.png)
 
 If we click on the latest version ('/2'), we can see all the relevant data for this version. 
 
-![Folder for version 2 of the example proposal](/img/politeia/prop-version2.png)
+![Folder for version 2 of the example proposal](../img/politeia/prop-version2.png)
 
 Below is a table with descriptions of the files and folders found in each proposal version folder. 
 

--- a/docs/advanced/navigating-politeia-data.md
+++ b/docs/advanced/navigating-politeia-data.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Navigating Politeia Data
+# ![](../img/dcr-icons/Politeia.svg){ .dcr-icon } Navigating Politeia Data
 
 ---
 

--- a/docs/advanced/premine.md
+++ b/docs/advanced/premine.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Premine
+# ![](../img/dcr-icons/PoWMine.svg){ .dcr-icon } Premine
 
 ---
 
@@ -66,7 +66,7 @@ After the final review was completed, 2,972 addresses were included in the airdr
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Further Reading
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } Further Reading
 
 #### Premine Commitments
 

--- a/docs/advanced/verifying-binaries.md
+++ b/docs/advanced/verifying-binaries.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Verifying Binaries
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Verifying Binaries
 ---
 
 ## Overview

--- a/docs/contributing/contributor-compensation.md
+++ b/docs/contributing/contributor-compensation.md
@@ -1,8 +1,8 @@
-# <img class="dcr-icon" src="/img/dcr-icons/ObtainingDecred.svg" /> Contributor Compensation
+# ![](../img/dcr-icons/ObtainingDecred.svg){ .dcr-icon } Contributor Compensation
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/User.svg" /> Contractors
+## ![](../img/dcr-icons/User.svg){ .dcr-icon } Contractors
 
 The term "Contractors" covers both **corporate contractors** and **independent contractors**.
 
@@ -20,7 +20,7 @@ Decred currently has over 50 contributors (independent contractors and employees
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Billing and Payments
+## ![](../img/dcr-icons/Wallet.svg){ .dcr-icon } Billing and Payments
 
 At the end of each month, each contractor prepares an invoice and submits it to the Decred Holdings Group LLC (DHG). The invoice lists the items the contractor has worked on and a charge (in USD) for each - typically these charges are for a number of hours worked at an agreed hourly rate.
 
@@ -50,7 +50,7 @@ project contributors to validate each others locations.
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/RFP.svg" /> Request for Proposals (RFP) - Historical
+## ![](../img/dcr-icons/RFP.svg){ .dcr-icon } Request for Proposals (RFP) - Historical
 
 Decred was launched with a Request For Proposal system in order to provide compensation for contributors working on larger or more significant projects. A document (RFP) would be produced which described the requirements and scope of a project, along with a clearly defined set of milestones and a reward specified in DCR. The RFP would be posted publicly and community members would be given a period of time to submit their proposals. After review, a proposal would be selected and awarded the contract.
 
@@ -60,6 +60,6 @@ The RFP process worked well for certain types of tasks, however a need arose to 
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Sources
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } Sources
 
 [^1]: Decred Blog, [2017 Decred Roadmap](https://blog.decred.org/2017/01/09/2017-Decred-Roadmap/)

--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Contributing to Decred
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Contributing to Decred
 
 ---
 
@@ -10,7 +10,7 @@ The strength of the open source approach to production is that individuals effic
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> Guidelines
+## ![](../img/dcr-icons/Dcrtl.svg){ .dcr-icon } Guidelines
 
 While the process of contributing will vary depending on domain, the basic steps will be as follows:
 
@@ -23,7 +23,7 @@ If contributing code, see the [contributor guidelines](https://devdocs.decred.or
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Introductions.svg" /> Becoming a paid Contractor
+## ![](../img/dcr-icons/Introductions.svg){ .dcr-icon } Becoming a paid Contractor
 
 Decred has a Treasury fund to pay contributors who work effectively to advance the project. To become a paid contractor one must demonstrate that one's work is of value to the project. The [recruitment blog post](https://blog.decred.org/2017/07/25/Decred-Recruiting/) by Project Organizer Jake Yocom-Piatt is the definitive guide to becoming a contractor.
 

--- a/docs/faq/blocks.md
+++ b/docs/faq/blocks.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Blocks.svg" /> Blocks
+# ![](../img/dcr-icons/Blocks.svg){ .dcr-icon } Blocks
 
 ---
 

--- a/docs/faq/configuration.md
+++ b/docs/faq/configuration.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Config1.svg" /> Configuration
+# ![](../img/dcr-icons/Config1.svg){ .dcr-icon } Configuration
 
 ---
 

--- a/docs/faq/errors.md
+++ b/docs/faq/errors.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Question.svg" /> Common Errors and Solutions
+# ![](../img/dcr-icons/Question.svg){ .dcr-icon } Common Errors and Solutions
 
 ## Proof-of-Stake (PoS)
 

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Meta.svg" /> General
+# ![](../img/dcr-icons/Meta.svg){ .dcr-icon } General
 
 ---
 

--- a/docs/faq/proof-of-stake/buying-tickets-and-fees.md
+++ b/docs/faq/proof-of-stake/buying-tickets-and-fees.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/BuyTicket.svg" /> Buying Tickets and Fees
+# ![](../../img/dcr-icons/BuyTicket.svg){ .dcr-icon } Buying Tickets and Fees
 
 ---
 

--- a/docs/faq/proof-of-stake/general.md
+++ b/docs/faq/proof-of-stake/general.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketLive.svg" /> Proof-of-Stake General FAQ
+# ![](../../img/dcr-icons/TicketLive.svg){ .dcr-icon } Proof-of-Stake General FAQ
 
 ---
 

--- a/docs/faq/proof-of-stake/solo-voting.md
+++ b/docs/faq/proof-of-stake/solo-voting.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Solo.svg" /> Solo Voting
+# ![](../../img/dcr-icons/Solo.svg){ .dcr-icon } Solo Voting
 
 ---
 

--- a/docs/faq/proof-of-stake/voting-service-providers.md
+++ b/docs/faq/proof-of-stake/voting-service-providers.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> Voting Service Providers
+# ![](../../img/dcr-icons/Servers.svg){ .dcr-icon } Voting Service Providers
 
 ---
 

--- a/docs/faq/proof-of-work-mining.md
+++ b/docs/faq/proof-of-work-mining.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Proof-of-Work (PoW) Mining
+# ![](../img/dcr-icons/PoWMine.svg){ .dcr-icon } Proof-of-Work (PoW) Mining
 
 ---
 

--- a/docs/faq/wallets-and-seeds.md
+++ b/docs/faq/wallets-and-seeds.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/CreateWallet.svg" /> Wallets and Seeds
+# ![](../img/dcr-icons/CreateWallet.svg){ .dcr-icon } Wallets and Seeds
 
 ---
 

--- a/docs/getting-started/articles-and-media.md
+++ b/docs/getting-started/articles-and-media.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" alt="Decred logo" src="/img/dcr-icons/DCRsymbol.svg" /> Articles and Media
+# ![](../img/dcr-icons/DCRsymbol.svg){ .dcr-icon } Articles and Media
 
 ---
 

--- a/docs/getting-started/beginner-guide.md
+++ b/docs/getting-started/beginner-guide.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Flag.svg" /> Beginner's Guide
+# ![](../img/dcr-icons/Flag.svg){ .dcr-icon } Beginner's Guide
 
 ---
 

--- a/docs/getting-started/joining-matrix-channels.md
+++ b/docs/getting-started/joining-matrix-channels.md
@@ -27,27 +27,27 @@ Element supports multiple platforms:
 
 When creating your account, select "Advanced" to choose to use a custom homeserver and enter `https://matrix.decred.org`.
 
-![Select Home Server](/img/matrix/matrix-02-select-home-server.png)
+![Select Home Server](../img/matrix/matrix-02-select-home-server.png)
 
 If you filled the email field, check your in-box to verify your account.
 
-![Create Account](/img/matrix/matrix-03-create-account.png)
+![Create Account](../img/matrix/matrix-03-create-account.png)
 
 Once in, you can begin exploring the different channels using the "Explore" feature.
 
-![Explore Rooms](/img/matrix/matrix-04-explore-rooms.png)
+![Explore Rooms](../img/matrix/matrix-04-explore-rooms.png)
 
 Most Decred projects have their own channel, joining areas you would like to contribute to is encouraged.
 
-![Room List](/img/matrix/matrix-05-room-list.png)
+![Room List](../img/matrix/matrix-05-room-list.png)
 
 Anyone can create new channels. Feel free to make one for your Decred related project or friend group.
 
-![Create Room](/img/matrix/matrix-06-create-room.png)
+![Create Room](../img/matrix/matrix-06-create-room.png)
 
 Decred is a community of builders. Price and trading discussions have their own `#trading:decred.org` channel.
 
-![Trading Channel](/img/matrix/matrix-07-trading-channel.png)
+![Trading Channel](../img/matrix/matrix-07-trading-channel.png)
 
 Keep in mind that Matrix channels is where the Decred community collaborates, works and hangs around. Be respectful.
 
@@ -59,4 +59,4 @@ Logging in from your mobile device requires you to setup the homeserver to `http
 
 After logging in for the first time, your rooms list will be empty. To find Decred channels tap the top-right menu dots, then "Global Search", and browse Decred's rooms directory.
 
-![Mobile App](/img/matrix/matrix-08-mobile.png)
+![Mobile App](../img/matrix/matrix-08-mobile.png)

--- a/docs/getting-started/obtaining-dcr.md
+++ b/docs/getting-started/obtaining-dcr.md
@@ -1,8 +1,8 @@
-# <img class="dcr-icon" src="/img/dcr-icons/ObtainingDecred.svg" /> Obtaining DCR
+# ![](../img/dcr-icons/ObtainingDecred.svg){ .dcr-icon } Obtaining DCR
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Info.svg" /> Overview
+## ![](../img/dcr-icons/Info.svg){ .dcr-icon } Overview
 
 This article discusses some of the ways a user can acquire Decred.
 
@@ -16,7 +16,7 @@ The five basic ways are:
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/PurchasingDCR.svg" /> Purchasing Decred
+## ![](../img/dcr-icons/PurchasingDCR.svg){ .dcr-icon } Purchasing Decred
 
 There is a variety of ways to purchase Decred listed on the [Decred website](https://decred.org/exchanges/).
 
@@ -26,25 +26,25 @@ There is a variety of ways to purchase Decred listed on the [Decred website](htt
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Mine for Decred (PoW)
+## ![](../img/dcr-icons/PoWMine.svg){ .dcr-icon } Mine for Decred (PoW)
 
 Proof-of-Work (PoW) is a measure of using computational power to create and verify the cryptographically secure blockchain.  This is similar to traditional Bitcoin mining. PoW mining is described in more detail [here](../mining/overview.md).
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Participate in Proof-of-Stake Voting
+## ![](../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Participate in Proof-of-Stake Voting
 
 Proof-of-Stake (PoS) voting is performed by stakeholders who lock a certain amount of their DCR in return for voting rights and a monetary reward. PoS voting is described in more detail [here](../proof-of-stake/overview.md).
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Credits.svg" /> Contribute to Decred
+## ![](../img/dcr-icons/Credits.svg){ .dcr-icon } Contribute to Decred
 
 Decred is currently recruiting contractors - members of the community who are paid in Decred for their contributions. Check out [Contributing](../contributing/overview.md) section for details and how to get involved.
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/SellGoods.svg" /> Sell/Trade Goods or Services for Decred
+## ![](../img/dcr-icons/SellGoods.svg){ .dcr-icon } Sell/Trade Goods or Services for Decred
 
 If you are an online merchant, there are some payment processors listed on the [Decred website](https://decred.org/exchanges/) which can help you accept Decred payments. Some of these payment processors can also provide integration with major e-commerce platforms.
 

--- a/docs/getting-started/using-the-block-explorer.md
+++ b/docs/getting-started/using-the-block-explorer.md
@@ -1,8 +1,8 @@
-# <img class="dcr-icon" src="/img/dcr-icons/BlockExplorer.svg" /> Using the Block Explorer
+# ![](../img/dcr-icons/BlockExplorer.svg){ .dcr-icon } Using the Block Explorer
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Info.svg" /> Overview
+## ![](../img/dcr-icons/Info.svg){ .dcr-icon } Overview
 
 All blocks and transactions on the Decred blockchain
 are visible through the use of the block explorer, [dcrdata](https://github.com/decred/dcrdata).
@@ -28,7 +28,7 @@ the value (in DCR) transmitted across the network.
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Blocks.svg" /> Blocks
+## ![](../img/dcr-icons/Blocks.svg){ .dcr-icon } Blocks
 
 Blocks can be found by searching for their block height number,
 clicking on a `Height` value from the home page, or from their
@@ -58,7 +58,7 @@ Option                   | Explanation
 `Version`                | The version of the block.
 `Nonce`                  | The value used by a miner to find the correct solution for this block.
 
-## <img class="dcr-icon" src="/img/dcr-icons/Transactions.svg" /> Transactions
+## ![](../img/dcr-icons/Transactions.svg){ .dcr-icon } Transactions
 
 This section lists all the transactions that were mined into this
 block. Transactions are chosen from the network mempool in order of
@@ -86,7 +86,7 @@ Note `Received Time`, `Mined Time`, and `Included in Block` will not have a valu
 
 ---
 
-### <img class="dcr-icon" src="/img/dcr-icons/TicketLive.svg" /> Ticket purchases
+### ![](../img/dcr-icons/TicketLive.svg){ .dcr-icon } Ticket purchases
 
 For a ticket purchase (stake submission) there are a few differences
 from a standard transaction shown.
@@ -105,7 +105,7 @@ is the address where change for this transaction will be sent.
 
 ---
 
-### <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Proof-of-stake votes
+### ![](../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Proof-of-stake votes
 
 Note the identifying terms in the details section: `Vote`, `Stake
 Base`, `Block Commitment`, and `Vote Bits`:

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -90,7 +90,7 @@ transaction sizes and where you are sending transactions to.
 #### Coin Type
 
 A unique number assigned to a cryptocurrency, which is used by [HD
-Wallets](#hd-wallet) during the process of generating public/private keypairs.
+Wallets](#hierarchical-deterministic-hd-wallet) during the process of generating public/private keypairs.
 Cryptocurrencies with assigned coin types are listed in
 [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
 The coin type of Decred is 42.

--- a/docs/governance/consensus-rule-voting/consensus-vote-archive.md
+++ b/docs/governance/consensus-rule-voting/consensus-vote-archive.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus Vote Archive
+# ![](../../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Consensus Vote Archive
 
 This section provides an archive for previous votes along with their outcomes.
 

--- a/docs/governance/consensus-rule-voting/how-to-vote.md
+++ b/docs/governance/consensus-rule-voting/how-to-vote.md
@@ -1,10 +1,10 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> How to Vote
+# ![](../../img/dcr-icons/TicketVoted.svg){ .dcr-icon } How to Vote
 
 This guide assumes you already have an active wallet and have purchased tickets. If not, please follow the [Voting Preparation](overview.md#voting-preparation) guide.
 
 The choice a ticket votes with depends on your vote preference at the time the ticket is chosen, not when it is bought. So you can set your choice at any time within the voting window and all future tickets will vote accordingly.
 
-## <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> Voting with a Voting Service Provider (VSP)
+## ![](../../img/dcr-icons/Servers.svg){ .dcr-icon } Voting with a Voting Service Provider (VSP)
 
 If your Voting Service Provider (VSP) has updated to the latest VSP software, you will find a 'Voting' page in the navigation menu with dropdown options for each agenda. After you've chosen how you want your tickets to vote, simply press the 'Update Voting Preferences' button to save your vote choices.
 
@@ -18,7 +18,7 @@ to set your vote.
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Solo.svg" /> Solo Voting
+## ![](../../img/dcr-icons/Solo.svg){ .dcr-icon } Solo Voting
 
 Through the command line, you'll want to familiarize yourself with the following commands:
 

--- a/docs/governance/consensus-rule-voting/how-to-vote.md
+++ b/docs/governance/consensus-rule-voting/how-to-vote.md
@@ -8,13 +8,13 @@ The choice a ticket votes with depends on your vote preference at the time the t
 
 If your Voting Service Provider (VSP) has updated to the latest VSP software, you will find a 'Voting' page in the navigation menu with dropdown options for each agenda. After you've chosen how you want your tickets to vote, simply press the 'Update Voting Preferences' button to save your vote choices.
 
-![VSP voting preferences](/img/vsp_voting_preferences.png)
+![VSP voting preferences](../../img/vsp_voting_preferences.png)
 
 You can also update your voting preferences via Decrediton.
 Under the 'Governance' section, 'Consensus Changes' tab, you'll find the option
 to set your vote.
 
-![Decrediton voting preferences](/img/decrediton_voting_preferences.png)
+![Decrediton voting preferences](../../img/decrediton_voting_preferences.png)
 
 ---
 

--- a/docs/governance/consensus-rule-voting/overview.md
+++ b/docs/governance/consensus-rule-voting/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Consensus Rule Voting
+# ![](../../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Consensus Rule Voting
 
 This page is intended to give a brief introduction to how consensus rule voting works and details the process for setting your tickets to cast your preferred vote for any agenda.
 
@@ -96,6 +96,6 @@ An official website, [voting.decred.org](https://voting.decred.org), has been se
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> Further Information
+## ![](../../img/dcr-icons/Sources.svg){ .dcr-icon } Further Information
 
 - Blog post announcing Consensus Rules Voting: <https://blog.decred.org/2016/11/16/Upgrading-Consensus/>

--- a/docs/governance/consensus-rule-voting/overview.md
+++ b/docs/governance/consensus-rule-voting/overview.md
@@ -76,7 +76,7 @@ All full nodes participating in the network will automatically activate the new 
 
 Below is a diagram of the entire cycle for a single agenda with consensus upgrades.
 
-![Consensus rule voting cycle](/img/voting-cycle.png)
+![Consensus rule voting cycle](../../img/voting-cycle.png)
 
 ---
 

--- a/docs/governance/consensus-rule-voting/verifying-votes.md
+++ b/docs/governance/consensus-rule-voting/verifying-votes.md
@@ -16,7 +16,7 @@ Vote transactions can be found in Decrediton by opening the History section of t
 This will display a list of all transactions involving the current wallet, but it is possible to filter the list  to show only vote transactions.
 Clicking on a vote transaction in this list will display detailed information about the transaction, including the transaction ID.
 
-![Finding a vote transaction ID in Decrediton](/img/verifying-votes/decrediton-vote-transaction-id.png)
+![Finding a vote transaction ID in Decrediton](../../img/verifying-votes/decrediton-vote-transaction-id.png)
 
 ### Command Line Interface (CLI)
 
@@ -61,7 +61,7 @@ Once the transaction ID of the ticket vote has been found, the voting preference
 To find the voting preferences of a ticket on [the block explorer](https://dcrdata.decred.org), simply enter the transaction ID obtained above into the search feature at the top of the homepage.
 The search result should show the detailed information about the transaction, including the voting preferences.
 
-![Verifying voting preferences in dcrdata](/img/verifying-votes/dcrdata-voting-prefs.png)
+![Verifying voting preferences in dcrdata](../../img/verifying-votes/dcrdata-voting-prefs.png)
 
 ### Command Line Interface (CLI)
 

--- a/docs/governance/consensus-rule-voting/verifying-votes.md
+++ b/docs/governance/consensus-rule-voting/verifying-votes.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Verifying Votes
+# ![](../../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Verifying Votes
 
 When a proof-of-stake ticket is called to vote on-chain, the voting preference of that ticket is permanently recorded on the Decred blockchain.
 It is possible to verify the voting preference of a ticket using either the Decred block explorer or the Command Line Interface (CLI).

--- a/docs/governance/overview.md
+++ b/docs/governance/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Governance.svg" /> Introduction to Decred Governance
+# ![](../img/dcr-icons/Governance.svg){ .dcr-icon } Introduction to Decred Governance
 
 ---
 

--- a/docs/governance/politeia/example-proposals.md
+++ b/docs/governance/politeia/example-proposals.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Example Politeia Proposals
+# ![](../../img/dcr-icons/Politeia.svg){ .dcr-icon } Example Politeia Proposals
 
 ---
 

--- a/docs/governance/politeia/overview.md
+++ b/docs/governance/politeia/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Politeia
+# ![](../../img/dcr-icons/Politeia.svg){ .dcr-icon } Politeia
 
 ---
 

--- a/docs/governance/politeia/politeia-censorship.md
+++ b/docs/governance/politeia/politeia-censorship.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Politeia Censorship
+# ![](../../img/dcr-icons/Politeia.svg){ .dcr-icon } Politeia Censorship
 
 ---
 

--- a/docs/governance/politeia/politeia-censorship.md
+++ b/docs/governance/politeia/politeia-censorship.md
@@ -20,7 +20,7 @@ When a user registers, a cryptographic identity (pub/priv key pair) is created. 
 
 If a user's proposal is censored, it will not appear publicly on Politeia, but will still be visible to the user and admins. The censored proposal will still appear on the user's `Your Proposals` page, along with the reason the proposal was censored. Below is an example proposal that was censored as spam. 
 
-![Example Censored Proposal](/img/politeia/censored-proposal.png)
+![Example Censored Proposal](../../img/politeia/censored-proposal.png)
 
 ## Recourse
 

--- a/docs/governance/politeia/proposal-guidelines.md
+++ b/docs/governance/politeia/proposal-guidelines.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Politeia.svg" /> Proposal Guidelines
+# ![](../../img/dcr-icons/Politeia.svg){ .dcr-icon } Proposal Guidelines
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ---
 
-## <img class="dcr-icon" alt="Decred logo" src="/img/dcr-icons/DCRsymbol.svg" /> What is Decred?
+## ![](img/dcr-icons/DCRsymbol.svg){ .dcr-icon } What is Decred?
 Decred (/ˈdi:ˈkred/, /dɪˈkred/, dee-cred) is a blockchain-based cryptocurrency with a strong focus on community input, open governance, and sustainable funding for development. It utilizes a hybrid Proof-of-Work (PoW) and Proof-of-Stake (PoS) mining system to ensure that a small group cannot dominate the flow of transactions or make changes to Decred without the input of the community. A unit of the currency is called a decred (DCR).
 
 ---

--- a/docs/lightning-network/watchtowers.md
+++ b/docs/lightning-network/watchtowers.md
@@ -24,7 +24,7 @@ This section can be skipped if you know what it means to _breach_ an LN channel.
 Lightning Network channels are realized on the blockchain as multisig, 2-of-2 outputs. This means both parties of a channel must cooperate in order to advance its _state_, which reflects the relative balances of the two participants and any outstanding (in-flight) payments:
 
 
-![Channel States](/img/lightning-network/channel-states.svg)
+![Channel States](../img/lightning-network/channel-states.svg)
 
 Each state corresponds to a _commitment transaction_: a transaction signed by both parties that spends the multisig channel output and that pays the correct relative amount to each party.
 

--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -77,7 +77,7 @@ To get started, use a scanning tool like [AngryIP](https://angryip.org/) or [Loc
 Enter the local network IP address of your miner in the URL bar of any web browser. A dashboard similar to the one shown below will pop up. We are setting up a Whatsminer D1, but the process is similar for other ASICs.
 
 
-![Rig Configuration Detail](/img/pow-mining-guide/rig_config.png)
+![Rig Configuration Detail](../img/pow-mining-guide/rig_config.png)
 
 ---
 
@@ -127,4 +127,4 @@ Once you have filled out the details, click Save & Apply. Setup is now complete.
 It will take about 5 minutes for your workers to appear on the stats page. To find your user, simply go to Luxor, login to your account and navigate to the Workers tab. You should see something like this:
 
 
-![Monitoring mining results with Luxor pool](/img/pow-mining-guide/monitoring-dashboard.png)
+![Monitoring mining results with Luxor pool](../img/pow-mining-guide/monitoring-dashboard.png)

--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Proof-of-Work (PoW) Mining
+# ![](../img/dcr-icons/PoWMine.svg){ .dcr-icon } Proof-of-Work (PoW) Mining
 
 ---
 
@@ -83,7 +83,7 @@ Enter the local network IP address of your miner in the URL bar of any web brows
 
 ## Solo Mining or Pool Mining
 
-##### <img class="dcr-icon" src="/img/dcr-icons/Solo.svg" /> Solo Mining
+##### ![](../img/dcr-icons/Solo.svg){ .dcr-icon } Solo Mining
 
 :fontawesome-solid-exclamation-triangle: **Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of up to 422Ph/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
 

--- a/docs/privacy/cspp/overview.md
+++ b/docs/privacy/cspp/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/LockEye.svg" /> CoinShuffle++
+# ![](../../img/dcr-icons/LockEye.svg){ .dcr-icon } CoinShuffle++
 
 ---
 

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/QuestionTicket.svg" /> How to Stake/Vote
+# ![](../img/dcr-icons/QuestionTicket.svg){ .dcr-icon } How to Stake/Vote
 
 ---
 
@@ -10,13 +10,13 @@ There are two ways to stake/vote: solo staking and staking using a VSP. The form
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Solo.svg" /> Solo PoS Voting
+## ![](../img/dcr-icons/Solo.svg){ .dcr-icon } Solo PoS Voting
 
 Solo PoS voting is currently only possible using the Decred command line tools. The [Buying Tickets with dcrwallet](../wallets/cli/dcrwallet-tickets.md) guide explains how to buy tickets using the CLI wallet `dcrwallet`.
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> PoS using a Voting Service Provider (VSP)
+## ![](../img/dcr-icons/Servers.svg){ .dcr-icon } PoS using a Voting Service Provider (VSP)
 
 A list of Voting Service Providers (VSPs) and statistics is maintained on the
 [:fontawesome-solid-external-link-square-alt: Decred.org website](https://decred.org/vsp/).

--- a/docs/proof-of-stake/overview.md
+++ b/docs/proof-of-stake/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/TicketVoted.svg" /> Proof-of-Stake (PoS) Voting
+# ![](../img/dcr-icons/TicketVoted.svg){ .dcr-icon } Proof-of-Stake (PoS) Voting
 
 ---
 

--- a/docs/proof-of-stake/redeem-script.md
+++ b/docs/proof-of-stake/redeem-script.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/QuestionTicket.svg" /> Redeem Script
+# ![](../img/dcr-icons/QuestionTicket.svg){ .dcr-icon } Redeem Script
 
 ---
 

--- a/docs/proof-of-stake/ticket-splitting.md
+++ b/docs/proof-of-stake/ticket-splitting.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/QuestionTicket.svg" /> Ticket Splitting
+# ![](../img/dcr-icons/QuestionTicket.svg){ .dcr-icon } Ticket Splitting
 
 ---
 

--- a/docs/research/blake-256-hash-function.md
+++ b/docs/research/blake-256-hash-function.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> BLAKE-256 Hash Function
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } BLAKE-256 Hash Function
 
 ---
 
@@ -136,7 +136,7 @@ In Decred, only a single round of BLAKE-256 hashing occurs versus two rounds of 
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Aumasson J., Henzen L., Meier W., Phan R. 2010. [SHA-3 proposal BLAKE](https://decred.org/research/aumasson2010.pdf)
 

--- a/docs/research/blake-256-hash-function.md
+++ b/docs/research/blake-256-hash-function.md
@@ -20,7 +20,7 @@ BLAKE is built on previously analyzed, and reliable components; the hash iterati
 
 The construction of a hash output is typically done by splitting the input data referred to as a 'message', into small blocks of fixed length and processed iteratively using a cryptographic compression function. The combination of calls to a compression function for processing the input data is an iteration mode (also referred to as a Domain Extender). The Merkle–Damgård (M-D) construction is the classic iteration mode used by MD5, SHA1, RIPEMD-160, and SHA2 hash functions. M-D splits the variable length input message into equal-sized message blocks _x_{: .dcrm } (i.e., 512 bits) of _n_{: .dcrm } blocks, the last block is padded as required and appended with the length of the message.
 
-![Merkle Damgard Construction](/img/merkle-damgard_construction.svg)
+![Merkle Damgard Construction](../img/merkle-damgard_construction.svg)
 
 **<em>Figure 1: Merkle–Damgård Construction</em>**
 
@@ -28,7 +28,7 @@ As shown in Figure 1 above, the output of the compression function _f_{: .dcrm }
 
 BLAKE uses HAIFA, which maintains the valuable properties of the M-D construction and adds to the security and scalability of the transformation. HAIFA is essentially an M-D construction but with a mandatory counter (number of bits hashed so far) and an optional salt (random data that used as an additional input).
 
-![HAIFA Construction](/img/haifa.svg)
+![HAIFA Construction](../img/haifa.svg)
 
 **<em>Figure 2: HAIFA Construction</em>**
 
@@ -36,7 +36,7 @@ This iteration mode solves many of the internal collision problems with the M-D 
 
 #### The local wide-pipe and ChaCha inspired core function
 
-![Local wide-pipe](/img/wide-pipe.svg)
+![Local wide-pipe](../img/wide-pipe.svg)
 
 **<em>Figure 3: Local wide-pipe construction of BLAKE's compression function, inherited from LAKE hash function [^6]</em>**
 
@@ -62,25 +62,25 @@ The security of a cryptographic hash function is determined by the number of que
 
 1. Pre-image resistance (one-way): Given the _y_{: .dcrm } as an output of the hash function, it is computationally infeasible to find message _x_{: .dcrm } such that _h(x) = y_{: .dcrm }. [^4]
 
-    ![Preimage resistance](/img/preimage_resistance.svg)
+    ![Preimage resistance](../img/preimage_resistance.svg)
 
     **<em>Figure 6: Pre-image resistance </em>**
 
 1. Second pre-image resistance (weak collision resistant): Given _x_{: .dcrm }, it is computationally infeasible to find a second pre-image  _x' ≠ x_{: .dcrm } such that _h(x) = h(x')_{: .dcrm } [^4]
 
-    ![Second pre-image resistance](/img/second-preimage_resistance.svg)
+    ![Second pre-image resistance](../img/second-preimage_resistance.svg)
 
     **<em>Figure 7: Second pre-image resistance </em>**
 
 1. Collision resistance (strong collision-resistant): It is computationally infeasible to find any two distinct inputs _x, x'_{: .dcrm } that hash to the same output such that _h(x) = h(x')_{: .dcrm } [^4]
 
-    ![Collision resistance](/img/collision_resistance.svg)
+    ![Collision resistance](../img/collision_resistance.svg)
 
     **<em>Figure 8: Collision resistance </em>**
 
 1. Length-extension resistance: Based on the hash of an unknown message _h(x)_{: .dcrm } and the length of the message _len(x)_{: .dcrm } it is not possible to choose a message _x'_{: .dcrm } to calculate _h(x')_{: .dcrm } such that _h(x') = h(x)_{: .dcrm }.
 
-    ![length extension](/img/length-extension.svg)
+    ![length extension](../img/length-extension.svg)
 
     **<em>Figure 9: Length extension attack: Since _x_{: .dcrm } and _x'_{: .dcrm } share the same first _n_{: .dcrm } blocks, the hash value _h(x)_{: .dcrm } is the intermediate hash value after first _n_{: .dcrm } blocks when computing _h(x')_{: .dcrm }</em> [^17]**
 

--- a/docs/research/block-production-times.md
+++ b/docs/research/block-production-times.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/PoWMine.svg" /> Block Production Times
+# ![](../img/dcr-icons/PoWMine.svg){ .dcr-icon } Block Production Times
 
 ---
 
@@ -29,6 +29,6 @@ The figure below shows shows the actual values plotted against the CDF used to d
 
 As we can see, it turns out that the actual distribution is quite close to the expected perfect distribution, which shows the network is operating in a healthy fashion. Note that the 0 to 10 and 0 to 30 second intervals slightly underperform the ideal values, which is expected because miners must wait for the votes to arrive before they can start building a new block, and this fact slightly skews the number of blocks found within the time spans downwards.
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: King S. and Nadal S. 2012. [PPCoin: Peer-to-Peer Crypto-Currency with Proof-of-Stake](https://decred.org/research/king2012.pdf).

--- a/docs/research/block-production-times.md
+++ b/docs/research/block-production-times.md
@@ -25,7 +25,7 @@ The table below shows the percentage of blocks we expect to find for different t
 
 The figure below shows shows the actual values plotted against the CDF used to derive expected percentages.
 
-![block times chart](/img/block_times_chart.png)
+![block times chart](../img/block_times_chart.png)
 
 As we can see, it turns out that the actual distribution is quite close to the expected perfect distribution, which shows the network is operating in a healthy fashion. Note that the 0 to 10 and 0 to 30 second intervals slightly underperform the ideal values, which is expected because miners must wait for the votes to arrive before they can start building a new block, and this fact slightly skews the number of blocks found within the time spans downwards.
 

--- a/docs/research/decentralized-stake-pooling.md
+++ b/docs/research/decentralized-stake-pooling.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Servers.svg" /> Decentralized Stake Pooling 
+# ![](../img/dcr-icons/Servers.svg){ .dcr-icon } Decentralized Stake Pooling 
 
 ---
 

--- a/docs/research/elliptic-curve-signature-algorithms.md
+++ b/docs/research/elliptic-curve-signature-algorithms.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Elliptic Curve Signature Algorithms
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Elliptic Curve Signature Algorithms
 
 ---
 
@@ -31,7 +31,7 @@ In the future, threshold signatures using dealerless secret sharing will also en
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Pornin T. 2013. [StackExchange Cryptography: Should we trust the NIST-recommended ECC parameters?](https://decred.org/research/pornin2013.pdf)
 [^2]: Solinas J. 2000. [Efficient arithmetic on Koblitz curves](https://decred.org/research/solinas2000.pdf).

--- a/docs/research/hybrid-design.md
+++ b/docs/research/hybrid-design.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Hybrid Design
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Hybrid Design
 
 ---
 
@@ -17,7 +17,7 @@ Bit flags are explicitly added to both the block header and votes so that either
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Bentov I., Lee C., Mizrahi A., Rosenfeld M. 2014. [Proof-of-activity: Extending Bitcoin's proof-of-work via proof-of-stake](https://decred.org/research/bentov2014.pdf).
 [^2]: Nakamoto S. 2008. [Bitcoin: A peer-to-peer electronic cash system](https://decred.org/research/nakamoto2008.pdf).

--- a/docs/research/miscellaneous-improvements.md
+++ b/docs/research/miscellaneous-improvements.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Miscellaneous Improvements
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Miscellaneous Improvements
 
 ---
 
@@ -8,7 +8,7 @@ It should also be noted that many well known mining attacks, such as selfish min
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Buterin V. 2014. [A next-generation smart contract and decentralized application platform](https://decred.org/research/buterin2014.pdf).
 [^2]: King S. and Nadal S. 2012. [PPCoin: Peer-to-peer crypto-currency with proof-of-stake](https://decred.org/research/king2012.pdf).

--- a/docs/research/overview.md
+++ b/docs/research/overview.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Info.svg" /> Overview
+# ![](../img/dcr-icons/Info.svg){ .dcr-icon } Overview
 
 ---
 
@@ -20,7 +20,7 @@ Research work in Decred is currently organized around the following subsections:
 * [Schnorr Signatures](schnorr-signatures.md)
 * [Miscellaneous Improvements](miscellaneous-improvements.md)
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Nakamoto S. 2008. [Bitcoin: A peer-to-peer electronic cash system](https://decred.org/research/nakamoto2008.pdf).
 [^2]: Buterin V. 2014. [A Next-generation smart contract and decentralized application platform](https://decred.org/research/buterin2014.pdf).

--- a/docs/research/schnorr-signatures.md
+++ b/docs/research/schnorr-signatures.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Schnorr Signatures
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Schnorr Signatures
 
 ---
 
@@ -30,6 +30,6 @@ It has been suggested that a Merkle tree containing all possible public key sums
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: Wuille P. 2015. [Tree signatures: Multisig on steroids using tree signatures](https://decred.org/research/wuille2015.pdf).

--- a/docs/research/signature-script-isolation-and-fraud-proofs.md
+++ b/docs/research/signature-script-isolation-and-fraud-proofs.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Code.svg" /> Signature Script Isolation and Fraud Proofs
+# ![](../img/dcr-icons/Code.svg){ .dcr-icon } Signature Script Isolation and Fraud Proofs
 
 ---
 
@@ -6,7 +6,7 @@ To prevent transaction malleability, the ability to generate a transaction with 
 
 ---
 
-## <img class="dcr-icon" src="/img/dcr-icons/Sources.svg" /> References
+## ![](../img/dcr-icons/Sources.svg){ .dcr-icon } References
 
 [^1]: von Saberhagen N. 2013. [CryptoNote v2.0](https://decred.org/research/saberhagen2013.pdf).
 [^2]: Maxwell G. 2015. [Bringing new elements to Bitcoin with sidechains](https://decred.org/research/maxwell2015.pdf).

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> CLI Installation guide
+# ![](../../img/dcr-icons/Dcrtl.svg){ .dcr-icon } CLI Installation guide
 
 Last updated for CLI release v{{ cliversion }}.
 

--- a/docs/wallets/cli/dcrctl-basics.md
+++ b/docs/wallets/cli/dcrctl-basics.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> `dcrctl` Basics
+# ![](../../img/dcr-icons/Dcrtl.svg){ .dcr-icon } `dcrctl` Basics
 
 **Prerequisites:**
 

--- a/docs/wallets/cli/dcrctl-rpc-commands.md
+++ b/docs/wallets/cli/dcrctl-rpc-commands.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Dcrtl.svg" /> `dcrctl` RPC Commands
+# ![](../../img/dcr-icons/Dcrtl.svg){ .dcr-icon } `dcrctl` RPC Commands
 
 Last updated for CLI release v{{ cliversion }}.
 

--- a/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
+++ b/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Options2.svg" /> `dcrd` and `dcrwallet` CLI Arguments
+# ![](../../img/dcr-icons/Options2.svg){ .dcr-icon } `dcrd` and `dcrwallet` CLI Arguments
 
 Last updated for CLI release v{{ cliversion }}.
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Decrediton Setup Guide
+# ![](../../img/dcr-icons/Wallet.svg){ .dcr-icon } Decrediton Setup Guide
 
 Last updated for Decrediton v{{ decreditonversion }}.
 

--- a/docs/wallets/decrediton/decrediton-setup.md
+++ b/docs/wallets/decrediton/decrediton-setup.md
@@ -61,21 +61,21 @@ The latest version of Decrediton can be downloaded from <https://decred.org/wall
 
 Opening Decrediton for the first time will display the following screen:
 
-![Decrediton startup screen](/img/decrediton/setup/startup.png)
+![Decrediton startup screen](../../img/decrediton/setup/startup.png)
 
 Select your desired language and press **Continue**. You will then be offered various privacy options which allow you to restrict which external services Decrediton will contact. The "Standard" option is recommended for most users, as this will enable all of the features in Decrediton and provide the best user experience.
 
-![Decrediton privacy options](/img/decrediton/setup/privacy-options.png)
+![Decrediton privacy options](../../img/decrediton/setup/privacy-options.png)
 
 A screen will be displayed which allows you to enable SPV mode if desired.
 
-![Decrediton SPV options](/img/decrediton/setup/spv-options.png)
+![Decrediton SPV options](../../img/decrediton/setup/spv-options.png)
 
 After making your choice, a short presentation explaining Decred blockchain, wallet, keys, staking/governance, and safety tips is shown. Please read these slides carefully if you are new to Decred.
 
 The following screen should be displayed next.
 
-![Decrediton blockchain download screen](/img/decrediton/setup/chain-downloading.png)
+![Decrediton blockchain download screen](../../img/decrediton/setup/chain-downloading.png)
 
 A large progress bar on this screen shows the progress of the blockchain download. If you chose to enable SPV mode, this bar will be filled immediately because downloading the blockchain is not required.
 
@@ -101,11 +101,11 @@ As Decrediton allows you to manage multiple wallets on one PC, you must give a n
 
 The 33 word seed for your new wallet is displayed on the screen (obscured in the below image). Record the seed and store it somewhere safe.
 
-![Decrediton wallet seed screen](/img/decrediton/setup/wallet-seed.png)
+![Decrediton wallet seed screen](../../img/decrediton/setup/wallet-seed.png)
 
 Press **Continue** and re-enter the missing words from your seed on the next screen. This is to confirm you have recorded your seed correctly.
 
-![Decrediton seed entry screen](/img/decrediton/setup/seed-entered.png)
+![Decrediton seed entry screen](../../img/decrediton/setup/seed-entered.png)
 
 Create a passphrase for your wallet. This passphrase will be used to unlock your wallet when creating transactions.
 
@@ -117,7 +117,7 @@ Press **Create Wallet** and your wallet setup is complete. You will be taken bac
 
 1. Open Decrediton and click on **Restore Existing Wallet**. If Decrediton is open and you have another wallet open, you'll need to first go to Settings and click **Close Wallet**.
 
-    ![Decrediton close wallet](/img/decrediton/setup/wallet-close.png)
+    ![Decrediton close wallet](../../img/decrediton/setup/wallet-close.png)
 
 1. Name your wallet. As Decrediton allows you to manage multiple wallets on one PC, you must give a name to your wallet so it can be identified.
 

--- a/docs/wallets/decrediton/decrediton-troubleshooting.md
+++ b/docs/wallets/decrediton/decrediton-troubleshooting.md
@@ -49,7 +49,7 @@ c:\[...]> decrediton.exe --debug
 
 1. Check if the blockchain is synchronized to the latest block. Look at the block height at the lower left corner of the screen and the latest block from [dcrdata.decred.org](https://dcrdata.decred.org)
 
-    ![Block Height](/img/decrediton/troubleshooting/blockheight.png)
+    ![Block Height](../../img/decrediton/troubleshooting/blockheight.png)
 
 1. Import **all** voting service provider ("stakepool") API keys that you previously used with this wallet. If you do not perform this step for all pools, your balance **will** be incorrect.
 
@@ -84,7 +84,7 @@ Check the following:
 
 ## Error "Already Have Transaction..."
 
-![Rebroadcast error](/img/decrediton/troubleshooting/rebroadcast.png)
+![Rebroadcast error](../../img/decrediton/troubleshooting/rebroadcast.png)
 
 If you receive a message similar to the one above, it means your dcrd node already has the transaction you're trying to publish. This is harmless, but if the transaction is left pending for a long time, you could try:
 
@@ -94,7 +94,7 @@ If you receive a message similar to the one above, it means your dcrd node alrea
 
 ## Cannot Purchase Tickets
 
-![Cannot purchase ticket](/img/decrediton/troubleshooting/purchaseticket.png)
+![Cannot purchase ticket](../../img/decrediton/troubleshooting/purchaseticket.png)
 
 This is usually caused by shutting down Decrediton before a ticket has been mined.
 
@@ -104,7 +104,7 @@ Perform the same steps as described in ["Cannot see all my coins"](#cannot-see-a
 
 If you can start the wallet but get error messages when performing an operation, then the first thing is to verify the wallet logs from within Decrediton. Access the Settings -> Logs page and look for any ERR messages:
 
-![Logs Page](/img/decrediton/troubleshooting/logs.png)
+![Logs Page](../../img/decrediton/troubleshooting/logs.png)
 
 ## How to backup VSP redeem script
 
@@ -114,8 +114,8 @@ Now is a good time to back up your VSPs multi-sig voting script (or "redeem scri
 
 Click on the gear icon next to your VSP. Then click on the donut icon that appears.
 
-![Purchase Tickets page](/img/decrediton/redeem-script.png)
+![Purchase Tickets page](../../img/decrediton/redeem-script.png)
 
 This will bring up your VSP's configuration details. Copy the string of characters in the `Script` field and store them in a safe location. 
 
-![Purchase Tickets page](/img/decrediton/redeem-script-field.png)
+![Purchase Tickets page](../../img/decrediton/redeem-script-field.png)

--- a/docs/wallets/decrediton/decrediton-troubleshooting.md
+++ b/docs/wallets/decrediton/decrediton-troubleshooting.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Troubleshooting Common Decrediton Problems
+# ![](../../img/dcr-icons/Wallet.svg){ .dcr-icon } Troubleshooting Common Decrediton Problems
 
 Last updated for Decrediton v{{ decreditonversion }}.
 

--- a/docs/wallets/decrediton/migrations.md
+++ b/docs/wallets/decrediton/migrations.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Decrediton Migrations
+# ![](../../img/dcr-icons/Wallet.svg){ .dcr-icon } Decrediton Migrations
 
 This page lists migrations performed by recent versions of Decrediton, what exactly they entail and possible impacts on custom setups.
 

--- a/docs/wallets/decrediton/trezor.md
+++ b/docs/wallets/decrediton/trezor.md
@@ -54,9 +54,9 @@ After setting up the Trezor device with a seed (and optionally enabling passphra
 
 To do so, connect your Trezor device to the computer, access the "Restore Existing Wallet", enable the "Trezor" switch and click on "Continue".
 
-![Restore Wallet](/img/decrediton/restore-wallet.png)
+![Restore Wallet](../../img/decrediton/restore-wallet.png)
 
-![Switch to Trezor-backed wallet](/img/decrediton/restore-wallet-trezor.png)
+![Switch to Trezor-backed wallet](../../img/decrediton/restore-wallet-trezor.png)
 
 Decrediton will fetch the master public key for the first account of the Trezor device and initialize an internal "Watching Only" dcrwallet instance.
 

--- a/docs/wallets/decrediton/trezor.md
+++ b/docs/wallets/decrediton/trezor.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Using a Trezor device with Decrediton
+# ![](../../img/dcr-icons/Wallet.svg){ .dcr-icon } Using a Trezor device with Decrediton
 
 Last updated for Decrediton v{{ decreditonversion }}.
 

--- a/docs/wallets/decrediton/upgrading-decrediton.md
+++ b/docs/wallets/decrediton/upgrading-decrediton.md
@@ -8,11 +8,11 @@ To upgrade Decrediton, simply download the new version and install it. You do no
 
 1. Download the latest version from [https://decred.org/wallets/](https://decred.org/wallets/) or by clicking on the `Update Available` button in the upper right-hand corner of Decrediton.
 
-    ![Decrediton update link](/img/decrediton/upgrading/update-available.png)
+    ![Decrediton update link](../../img/decrediton/upgrading/update-available.png)
 
     Click on the link for your OS and download the installer.
 
-    ![Decrediton update link](/img/decrediton/upgrading/download-link.png)
+    ![Decrediton update link](../../img/decrediton/upgrading/download-link.png)
 
     !!! Warning "Security Tip"
     

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -18,7 +18,7 @@ The overview tab gives a quick summary of your total DCR (available and locked i
 
 Graphs of your balance, ticket activity and transaction history over the last two weeks can be viewed here.
 
-![Overview Tab](/img/decrediton/overview.png)
+![Overview Tab](../../img/decrediton/overview.png)
 
 ---
 
@@ -34,7 +34,7 @@ There are additional buttons here which can be used to create more advanced tran
 
 Once you have entered the details of your transaction, the estimated fee and transaction size are detailed below the input panels. After reviewing these numbers, you can press the **Send** button and your transaction will be broadcast.
 
-![Send Tab](/img/decrediton/send.png)
+![Send Tab](../../img/decrediton/send.png)
 
 ### Receive
 
@@ -42,20 +42,20 @@ This is where you can generate wallet addresses to give to other people so they 
 send you DCR. The address is displayed in the blue text box - it's the line that starts with Ds, or Ts on testnet. Simply choose the account you want funds to go to and select the **Generate New Address** button.
 Decred addresses can be used as many times as you want, but for privacy reasons it's best to generate a new one for each transaction. There's around 1.4E48 (that's 14 followed by 47 zeroes) addresses available so you don't need to worry about running out.
 
-![Receive Tab](/img/decrediton/receive.png)
+![Receive Tab](../../img/decrediton/receive.png)
 
 ### History
 
 This tab shows a list of all transactions that have occurred involving this wallet. A dropdown menu allows filtering the list by transaction type: regular, ticket and vote transactions. The transaction hash can be used with the
 [block explorer](../../getting-started/using-the-block-explorer.md) to see more information about the transaction.
 
-![History Tab](/img/decrediton/history.png)
+![History Tab](../../img/decrediton/history.png)
 
 ### Export
 
 This tab shows allows you to export your transaction history in a .csv format. You can choose the data you wish to export, select a location to output the generated file, and then press the **Export** button.
 
-![Export Tab](/img/decrediton/export-transactions.png)
+![Export Tab](../../img/decrediton/export-transactions.png)
 
 <!-- TODO add Lightning Transactions here -->
 
@@ -65,7 +65,7 @@ This tab shows allows you to export your transaction history in a .csv format. Y
 
 The governance tab enables users holding tickets to have their say on Decred's governance. Here you can browse and vote upon [Politeia proposals](../../governance/politeia/overview.md), and you can set your voting preferences for on chain [consensus rule votes](../../governance/consensus-rule-voting/overview.md). Your privacy settings must allow Decrediton to contact Politeia to download proposal information.
 
-![Governance page](/img/decrediton/governance.png)
+![Governance page](../../img/decrediton/governance.png)
 
 Politeia proposals can be filtered by "Under Discussion", "Under Vote", "Finished Voting" and "Abandoned". The "Create Proposal" button will open <https://proposals.decred.org> in your browser.
 
@@ -75,7 +75,7 @@ You are able to vote on proposals if the following two criteria are met:
 
 1. You owned live proof-of-stake tickets when the proposal was opened for voting
 
-![Consensus rule changes Settings page](/img/decrediton/consensus-rule-voting.png)
+![Consensus rule changes Settings page](../../img/decrediton/consensus-rule-voting.png)
 
 The Consensus Changes page shows all of the agendas which are currently up for vote on the Decred blockchain.
 You can read the details of each agenda and choose which way you would like to vote on each issue.
@@ -90,7 +90,7 @@ The staking tab is split into four sections:
 
 ### Purchase Tickets
 
-![Purchase Tickets page](/img/decrediton/purchase-tickets.png)
+![Purchase Tickets page](../../img/decrediton/purchase-tickets.png)
 
 The total number of tickets you currently own is at the top of the page:
 
@@ -104,7 +104,7 @@ In order to purchase tickets you just need to select which account to purchase t
 
 The "Automatic Ticket Buyer" panel allows you to enable the automated ticket buyer - Decrediton will continually buy tickets for you for as long as you keep it running. You can configure how the ticket buyer works using the options:
 
-![Automatic Purchase panel](/img/decrediton/autobuyer.png)
+![Automatic Purchase panel](../../img/decrediton/autobuyer.png)
 
 - **VSP** - Which VSP to purchase tickets with
 - **From** - Funds to purchase tickets will come from this account
@@ -122,7 +122,7 @@ This tab shows a summary of all of your tickets which voted, expired or were mis
 
 This page displays various statistics about all of the available VSPs. The dropdown can be used to change the currently displayed VSP.
 
-![VSP statistics page](/img/decrediton/pool-stats.png)
+![VSP statistics page](../../img/decrediton/pool-stats.png)
 
 ---
 
@@ -132,7 +132,7 @@ This page displays various statistics about all of the available VSPs. The dropd
 
 The Security Center tab offers two key features - the ability to sign and verify messages using your private key, and the ability to validate addresses.
 
-![Security Tab](/img/decrediton/security.png)
+![Security Tab](../../img/decrediton/security.png)
 
 ### Sign and Verify messages
 
@@ -159,7 +159,7 @@ useful for those who run businesses and wish to keep separate accounts for
 tax records for example. Transferring DCR across accounts will create a
 transaction on the blockchain.
 
-![Accounts Tab](/img/decrediton/accounts.png)
+![Accounts Tab](../../img/decrediton/accounts.png)
 
 ---
 
@@ -169,4 +169,4 @@ The settings tab allows you to customize the units DCR amounts are displayed in 
 
 The settings tab is also where you come to change your private passphrase.
 
-![Settings Tab](/img/decrediton/settings.png)
+![Settings Tab](../../img/decrediton/settings.png)

--- a/docs/wallets/decrediton/using-decrediton.md
+++ b/docs/wallets/decrediton/using-decrediton.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Using Decrediton
+# ![](../../img/dcr-icons/Wallet.svg){ .dcr-icon } Using Decrediton
 
 Last updated for Decrediton v{{ decreditonversion }}.
 

--- a/docs/wallets/hardware-wallets.md
+++ b/docs/wallets/hardware-wallets.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Hardware Wallets
+# ![](../img/dcr-icons/Wallet.svg){ .dcr-icon } Hardware Wallets
 
 Traditional software wallets such as Decrediton store your private keys in a
 file on your computer.

--- a/docs/wallets/mobile-wallets.md
+++ b/docs/wallets/mobile-wallets.md
@@ -1,4 +1,4 @@
-# <img class="dcr-icon" src="/img/dcr-icons/Wallet.svg" /> Mobile Wallets
+# ![](../img/dcr-icons/Wallet.svg){ .dcr-icon } Mobile Wallets
 
 Mobile Decred wallets are available for both
 [Android](https://play.google.com/store/apps/details?id=com.decred.dcrandroid.mainnet)


### PR DESCRIPTION
Also using relative paths for images will enable mkdocs to give build-time warnings about any missing images or incorrect image paths.