### PR TITLE
Update to mkdocs-material 7.2.6.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -130,6 +130,13 @@ details .md-typeset__table {
     white-space: nowrap;
 }
 
+.md-typeset table:not([class]) {
+    border: 0;
+    box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.05rem rgb(0 0 0 / 10%);
+}
+.md-typeset table:not([class]) tr:first-child td {
+    border-top: 0;
+}
 .md-typeset table:not([class]) th{
     background-color: var(--dcrdocs-table-bg-color);
     font-size: 13px;
@@ -142,6 +149,10 @@ details .md-typeset__table {
 
 .md-typeset .admonition p{
     font-size: 14px;
+}
+
+.md-typeset blockquote p{
+    padding: 12px 0 12px;
 }
 
 .md-typeset code {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs==1.2.2
-mkdocs-material==7.2.2
-mkdocs-material-extensions==1.0.1
+mkdocs-material==7.2.6
 mkdocs-markdownextradata-plugin==0.2.4


### PR DESCRIPTION
- No longer need to specify `mkdocs-material-extensions` as an explicit dependency. It is included in `mkdocs-material` dependencies.
- Update css to maintain table and blockquote styles which changed slightly in recent `mkdocs-material` patches.