### PR TITLE
Update mkdocs-material.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-mkdocs==1.2.2
-mkdocs-material==7.2.6
+mkdocs-material==7.3.4
 mkdocs-markdownextradata-plugin==0.2.4


### PR DESCRIPTION
This also removes mkdocs as an explicit dependency because mkdocs-material will automatically pull the latest version of mkdocs it is compatible with.