### PR TITLE
Bump for cli 1.7.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018-2021 The Decred developers
+Copyright (c) 2018-2022 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -5,7 +5,7 @@ dcrdocs is licensed under the [copyfree](http://copyfree.org) ISC License.
 ---
 
 Copyright © 2013-2015 The btcsuite developers.  
-Copyright © 2015-2021 The Decred developers.
+Copyright © 2015-2022 The Decred developers.
 
 Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -76,7 +76,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
+        The `.tar.gz` file will be extracted into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
 
 ---
 

--- a/docs/advanced/manual-cli-install.md
+++ b/docs/advanced/manual-cli-install.md
@@ -28,6 +28,7 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         | Architecture | Filename                                       |
         | ------------ | ---------------------------------------------- |
         | 64-bit       | `decred-darwin-amd64-v{{ cliversion }}.tar.gz` |
+        | M1 Chip      | `decred-darwin-arm64-v{{ cliversion }}.tar.gz` |
 
     1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](verifying-binaries.md).
 
@@ -59,6 +60,23 @@ The newest binary releases can be found [here](https://github.com/decred/decred-
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
         Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion }}`).
+
+=== "BSD"
+
+    1. Download the correct file for your computer:
+
+        | Architecture  | Filename                                        |
+        | ------------- | ----------------------------------------------- |
+        | FreeBSD amd64 | `decred-freebsd-amd64-v{{ cliversion }}.tar.gz` |
+        | OpenBSD amd64 | `decred-openbsd-amd64-v{{ cliversion }}.tar.gz` |
+
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](verifying-binaries.md).
+
+    1. Navigate to download location and extract the `.tar.gz` file:
+
+        **Terminal:** use the `tar -xvzf filename.tar.gz` command.
+
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
 
 ---
 

--- a/docs/advanced/verifying-binaries.md
+++ b/docs/advanced/verifying-binaries.md
@@ -271,17 +271,17 @@ In a terminal, navigate to where you saved both the `manifest.txt` and the
 $ gpg --verify <your manifest.txt.asc file>
 ```
 
-For example, if you wanted to verify `decred-v1.5.1-manifest.txt.asc`:
+For example, if you wanted to verify `decred-v1.7.1-manifest.txt.asc`:
 
 ```no-highlight
-$ gpg --verify decred-v1.5.1-manifest.txt.asc
+$ gpg --verify decred-v1.7.1-manifest.txt.asc
 ```
 
 Example output:
 
 ```no-highlight
-gpg: assuming signed data in 'decred-v1.5.1-manifest.txt'
-gpg: Signature made 01/29/20 15:17:58 Eastern Standard Time
+gpg: assuming signed data in 'decred-v1.7.1-manifest.txt'
+gpg: Signature made Thu 17 Feb 2022 10:19:22 AM EST
 gpg:                using RSA key F516ADB7A069852C7C28A02D6D897EDF518A031D
 gpg: Good signature from "Decred Release <release@decred.org>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
@@ -333,7 +333,7 @@ There are many ways to generate a SHA-256 hash, but here are a few:
 Example output:
 
 ```no-highlight
-0c43caffa428cebb8a4d3c8efb2a341220fd1c232640ff3b4403ff67e1873e1a  decred-linux-amd64-v1.5.1.tar.gz
+92e0618b351042dc538c6614b475db4574ac3dfae48fae76cc1777b3972b502e  decred-linux-amd64-v1.7.1.tar.gz
 ```
 
 If your output hash matches the hash from the manifest, you're done! The binary

--- a/docs/advanced/verifying-binaries.md
+++ b/docs/advanced/verifying-binaries.md
@@ -254,8 +254,8 @@ Example output:
 pub   rsa4096 2016-01-27 [SC]
       FD13B6835E248FAF4BD1838D6DF634AA7608AF04
 uid           [ unknown] Decred Release <release@decred.org>
-sub   rsa4096 2016-01-27 [S]
 sub   rsa4096 2016-01-27 [E]
+sub   rsa4096 2016-01-27 [S]
 ```
 
 ### Verify that the manifest was directly signed by the Decred project
@@ -271,17 +271,17 @@ In a terminal, navigate to where you saved both the `manifest.txt` and the
 $ gpg --verify <your manifest.txt.asc file>
 ```
 
-For example, if you wanted to verify `decred-v1.7.1-manifest.txt.asc`:
+For example, if you wanted to verify `decred-v1.7.2-manifest.txt.asc`:
 
 ```no-highlight
-$ gpg --verify decred-v1.7.1-manifest.txt.asc
+$ gpg --verify decred-v1.7.2-manifest.txt.asc
 ```
 
 Example output:
 
 ```no-highlight
-gpg: assuming signed data in 'decred-v1.7.1-manifest.txt'
-gpg: Signature made Thu 17 Feb 2022 10:19:22 AM EST
+gpg: assuming signed data in 'decred-v1.7.2-manifest.txt'
+gpg: Signature made Wed 11 May 2022 11:41:05 AM EDT
 gpg:                using RSA key F516ADB7A069852C7C28A02D6D897EDF518A031D
 gpg: Good signature from "Decred Release <release@decred.org>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
@@ -333,7 +333,7 @@ There are many ways to generate a SHA-256 hash, but here are a few:
 Example output:
 
 ```no-highlight
-92e0618b351042dc538c6614b475db4574ac3dfae48fae76cc1777b3972b502e  decred-linux-amd64-v1.7.1.tar.gz
+ab0c4d53576f4bd486c8c64451edc0b000a5eaae6e18e29e367f24522e11a7c6  decred-linux-amd64-v1.7.2.tar.gz
 ```
 
 If your output hash matches the hash from the manifest, you're done! The binary

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -12,11 +12,15 @@ Last updated for CLI release v{{ cliversion }}.
 
 === "macOS"
 
-    1. Download the `dcrinstall-darwin-amd64-v{{ cliversion }}` file. (32 bit builds for macOS are not available):
+    1. Download the correct file:
 
+        For older, 64-bit hardware, download the `decred-darwin-amd64-v{{ cliversion }}.tar.gz` file.
+        
+        For Hardware with the new M1 Chip, download the `decred-darwin-arm64-v{{ cliversion }}.tar.gz` file.
+    
     1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
 
-    1. Make `dcrinstall-darwin-amd64-v{{ cliversion }}` an executable within your terminal, and run it:
+    1. Make the downloaded file an executable within your terminal and run it:
 
         Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run `chmod` with `u+x` mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
 

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -4,21 +4,36 @@ Last updated for CLI release v{{ cliversion }}.
 
 ---
 
-`dcrinstall` is the recommended method to install the Decred command line interface tools `dcrd`, `dcrwallet`, and `dcrctl`.
+`dcrinstall` makes it easy to install Decred Command Line Interface (CLI) tools on a single machine. Everything is automatically configured to work right out of the box. This includes `dcrd`, `dcrwallet`, `dcrctl`, `dcrlnd`, and `dcrlncli`.
 
-`dcrinstall` is an automatic installer and upgrader for the Decred software. The newest release can be found here: <https://github.com/decred/decred-release/releases>. Binaries are provided for Windows, macOS and Linux.
+`dcrinstall` is an automatic installer and upgrader for the Decred software. The newest release can be found here: <https://github.com/decred/decred-release/releases>. Binaries are provided for Windows, macOS, Linux, and BSD.
 
-`dcrinstall` will automatically download the precompiled, signed binary package found on GitHub, verify the signature of this package, copy the binaries within the package to a specific folder dependent on OS, create configuration files with settings to allow the 3 applications to communicate with each other, and run you through the wallet creation process. After running through `dcrinstall`, you will be able to launch the software with no additional configuration.
+`dcrinstall` will automatically download the precompiled, signed binary package found on GitHub, verify the signature of this package, copy the binaries within the package to a specific folder dependent on OS, create configuration files with settings to allow the 3 applications to communicate with each other, and run you through the wallet creation process. After running `dcrinstall`, you will be able to launch the software with no additional configuration.
+
+!!! tip "Looking for a more advanced setup?"
+    
+    If you are interested in advanced configurations or Solo POS Voting, consider reading the [Solo Voting](../../advanced/solo-proof-of-stake-voting.md) guide.
+
+    If you are interested in networking between multiple devices, consider reading the [Secure Cold Wallet](../../advanced/secure-cold-wallet-setup.md) guide.
 
 === "macOS"
 
-    1. Download the correct file:
+    1. Download the correct file for your computer:
 
-        For older, 64-bit hardware, download the `decred-darwin-amd64-v{{ cliversion }}.tar.gz` file.
-        
-        For Hardware with the new M1 Chip, download the `decred-darwin-arm64-v{{ cliversion }}.tar.gz` file.
+        | Architecture | Filename                                       |
+        | ------------ | ---------------------------------------------- |
+        | 64-bit       | `decred-darwin-amd64-v{{ cliversion }}.tar.gz` |
+        | M1 Chip      | `decred-darwin-arm64-v{{ cliversion }}.tar.gz` |
     
     1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
+
+    1. Navigate to download location and extract the `.tar.gz` file:
+
+        **Finder:** simply double click on the `.tar.gz` file.
+
+        **Terminal:** use the `tar -xvzf filename.tar.gz` command.
+
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-darwin-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-darwin-amd64-v{{ cliversion }}`).
 
     1. Make the downloaded file an executable within your terminal and run it:
 
@@ -34,17 +49,24 @@ Last updated for CLI release v{{ cliversion }}.
 
 === "Linux"
 
-    1. Download the correct file:
+    1. Download the correct file for your computer:
 
-        For 32-bit computers, download the `dcrinstall-linux-386-v{{ cliversion }}` file.
-
-        For 64-bit computers, download the `dcrinstall-linux-amd64-v{{ cliversion }}` file.
-
-        For 32-bit ARM computers, download the `dcrinstall-linux-arm-v{{ cliversion }}` file.
-
-        For 64-bit ARM computers, download the `dcrinstall-linux-arm64-v{{ cliversion }}` file.
+        | Architecture | Filename                                      |
+        | ------------ | --------------------------------------------- |
+        | 32-bit       | `decred-linux-386-v{{ cliversion }}.tar.gz`   |
+        | 64-bit       | `decred-linux-amd64-v{{ cliversion }}.tar.gz` |
+        | 32-bit ARM   | `decred-linux-arm-v{{ cliversion }}.tar.gz`   |
+        | 64-bit ARM   | `decred-linux-arm64-v{{ cliversion }}.tar.gz` |
 
     1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
+
+    1. Navigate to download location and extract the `.tar.gz` file:
+
+        **Ubuntu File Browser:** simply right click on the `.tar.gz` file and select "Extract Here".
+
+        **Terminal:** use the `tar -xvzf filename.tar.gz` command.
+
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-linux-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-linux-amd64-v{{ cliversion }}`).
 
     1. Make the downloaded file an executable within your terminal and run it:
 
@@ -60,14 +82,48 @@ Last updated for CLI release v{{ cliversion }}.
 
 === "Windows"
 
-    1. Download the correct file:
+    1. Download the correct file for your computer:
 
-        For 32-bit computers, download the `dcrinstall-windows-386-v{{ cliversion }}.exe` file.
-
-        For 64-bit computers, download the `dcrinstall-windows-amd64-v{{ cliversion }}.exe` file.
+        | Architecture | Filename                                     |
+        | ------------ | ---------------------------------------------|
+        | 32-bit       | `decred-windows-386-v{{ cliversion }}.zip`   |
+        | 64-bit       | `decred-windows-amd64-v{{ cliversion }}.zip` |
 
     1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
+
+    1. Navigate to download location and extract the `.zip` file:
+
+        Right click on the `.zip` file, select "Extract All..." and a prompt should open asking for the directory to use. The default will extract the `.zip` to a folder with the same name.
 
     1. Run the dcrinstall executable file. You can either double click it or run it from the Command Prompt.
 
     1. The binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `%HOMEPATH%\decred\` directory (usually `%HOMEPATH%` is `C:\Users\<username>\`). Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.
+
+=== "BSD"
+
+    1. Download the correct file for your computer:
+
+        | Architecture  | Filename                                        |
+        | ------------- | ----------------------------------------------- |
+        | FreeBSD amd64 | `decred-freebsd-amd64-v{{ cliversion }}.tar.gz` |
+        | OpenBSD amd64 | `decred-openbsd-amd64-v{{ cliversion }}.tar.gz` |
+
+    1. For your security, verify that your download hash matches the hash in the Decred releases manifest. For detailed instructions, read about [Verifying Binaries](../../advanced/verifying-binaries.md).
+
+    1. Navigate to download location and extract the `.tar.gz` file:
+
+        **Terminal:** use the `tar -xvzf filename.tar.gz` command.
+
+        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
+
+    1. Make the downloaded file an executable within your terminal and run it:
+
+        Navigate to the directory where the dcrinstall file was downloaded using the `cd` command, run `chmod` with `u+x` mode on the dcrinstall file, and run the executable that is created. Below is an example of the commands (change directories or filename as needed):
+
+        `cd ~/Downloads/`
+
+        `chmod u+x dcrinstall-linux-amd64-v{{ cliversion }}`
+
+        `./dcrinstall-linux-amd64-v{{ cliversion }}`
+
+    1. The binaries for `dcrd`, `dcrwallet`, and `dcrctl` can now be found in the `~/decred/` directory. Before the `dcrinstall` process completes, you will be taken to the wallet creation prompt. Follow the steps within the [Wallet Creation Walkthrough](../../wallets/cli/dcrwallet-setup.md#wallet-creation-walkthrough) of the dcrwallet Setup guide to finish.

--- a/docs/wallets/cli/cli-installation.md
+++ b/docs/wallets/cli/cli-installation.md
@@ -12,7 +12,7 @@ Last updated for CLI release v{{ cliversion }}.
 
 !!! tip "Looking for a more advanced setup?"
     
-    If you are interested in advanced configurations or Solo POS Voting, consider reading the [Solo Voting](../../advanced/solo-proof-of-stake-voting.md) guide.
+    If you are interested in advanced configurations or Solo PoS Voting, consider reading the [Solo Voting](../../advanced/solo-proof-of-stake-voting.md) guide.
 
     If you are interested in networking between multiple devices, consider reading the [Secure Cold Wallet](../../advanced/secure-cold-wallet-setup.md) guide.
 
@@ -114,7 +114,7 @@ Last updated for CLI release v{{ cliversion }}.
 
         **Terminal:** use the `tar -xvzf filename.tar.gz` command.
 
-        Both of these should extract the `.tar.gz` file into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
+        The `.tar.gz` file will be extracted into a folder that shares the same name. (e.g. `tar -xvzf decred-openbsd-amd64-v{{ cliversion }}.tar.gz` should extract to `decred-openbsd-amd64-v{{ cliversion }}`).
 
     1. Make the downloaded file an executable within your terminal and run it:
 

--- a/docs/wallets/cli/dcrctl-rpc-commands.md
+++ b/docs/wallets/cli/dcrctl-rpc-commands.md
@@ -40,8 +40,6 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `getblockhash`            | `index`
     `getblockheader`          | `"hash"` (`verbose=true`)
     `getblocksubsidy`         | `height` `voters`
-    `getcfilter`              | `"hash"` `"filtertype"`
-    `getcfilterheader`        | `"hash"` `"filtertype"`
     `getcfilterv2`            | `"blockhash"`
     `getchaintips`            |
     `getcoinsupply`           |
@@ -66,15 +64,17 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `getticketpoolvalue`      |
     `gettreasurybalance`      | (`"hash"` `verbose=false`)
     `gettreasuryspendvotes`   | (`"block"` `["tspend",...]`)
-    `gettxout`                | `"txid"` `vout` (`includemempool=true`)
+    `gettxout`                | `"txid"` `vout` `tree` (`includemempool=true`)
     `gettxoutsetinfo`         |
     `getvoteinfo`             | `version`
     `getwork`                 | (`"data"`)
     `help`                    | (`"command"`)
+    `invalidateblock`         | `"blockhash"`
     `livetickets`             |
     `missedtickets`           |
     `node`                    | `"connect|remove|disconnect"` `"target"` (`"perm|temp"`)
     `ping`                    |
+    `reconsiderblock`         | `"blockhash"`
     `regentemplate`           |
     `searchrawtransactions`   | `"address"` (`verbose=1` `skip=0` `count=100` `vinextra=0` `reverse=false` `["filteraddr",...]`)
     `sendrawtransaction`      | `"hextx"` (`allowhighfees=false`)
@@ -109,6 +109,7 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `createrawtransaction`    | `[{"amount":n.nnn,"txid":"value","vout":n,"tree":n},...]` `{"address":amount,...}` (`locktime` `expiry`)
     `createsignature`         | `"address"` `inputindex` `hashtype` `"previouspkscript"` `"serializedtransaction"`
     `createvotingaccount`     | `"name"` `"pubkey"` (`childindex=0`)
+    `disapprovepercent`       |
     `discoverusage`           | (`"startblock"` `discoveraccounts` `gaplimit`)
     `dumpprivkey`             | `"address"`
     `fundrawtransaction`      | `"hexstring"` `"fundaccount"` (`{"changeaddress":changeaddress,"feerate":feerate,"conftarget":conftarget}`)
@@ -119,9 +120,13 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `getbalance`              | (`"account"` `minconf=1`)
     `getbestblock`            |
     `getbestblockhash`        |
+    `getblock`                | `"hash"` (`verbose=true` `verbosetx=false`)
     `getblockcount`           |
     `getblockhash`            | `index`
+    `getblockheader`          | `"hash"` (`verbose=true`)
+    `getcfilterv2`            | `"blockhash"`
     `getcoinjoinsbyacct`      |
+    `getcurrentnet`           |
     `getinfo`                 |
     `getmasterpubkey`         | (`"account"`)
     `getmultisigoutinfo`      | `"hash"` `index`
@@ -133,6 +138,7 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `getstakeinfo`            |
     `gettickets`              | `includeimmature`
     `gettransaction`          | `"txid"` (`includewatchonly=false`)
+    `gettxout`                | `"txid"` `vout` `tree` (`includemempool=true`)
     `getunconfirmedbalance`   | (`"account"`)
     `getvotechoices`          | `("tickethash")`
     `getwalletfee`            |
@@ -153,6 +159,7 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `lockunspent`             | `unlock` `[{"amount":n.nnn,"txid":"value","vout":n,"tree":n},...]`
     `mixaccount`              |
     `mixoutput`               | `"outpoint"`
+    `processunmanagedticket`  | (`"tickethash"`)
     `purchaseticket`          | `"fromaccount"` `spendlimit` (`minconf=1` `"ticketaddress"` `numtickets=1` `"pooladdress"` `poolfees` `expiry` `"comment"` `dontsigntx`)
     `redeemmultisigout`       | `"hash"` `index` `tree` (`"address"`)
     `redeemmultisigouts`      | `"fromscraddress"` (`"toaddress"` `number`)
@@ -167,8 +174,9 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `sendtomultisig`          | `"fromaccount"` `amount` `["pubkey",...]` (`nrequired=1` `minconf=1` `"comment"`)
     `sendtotreasury`          | `amount`
     `setaccountpassphrase`    | `"account"` `"passphrase"`
-    `settreasurypolicy`       | `"key"` `"policy"`
-    `settspendpolicy`         | `"hash"` `"policy"`
+    `setdisapprovepercent`    | `percent`
+    `settreasurypolicy`       | `"key"` `"policy"` (`"ticket"`)
+    `settspendpolicy`         | `"hash"` `"policy"` (`"ticket"`)
     `settxfee`                | `amount`
     `setvotechoice`           | `"agendaid"` `"choiceid"` (`"tickethash"`)
     `signmessage`             | `"address"` `"message"`
@@ -176,10 +184,11 @@ Below are some common RPC commands for dcrd and dcrwallet. For a full list of su
     `signrawtransactions`     | `["rawtx",...]` (`send=true`)
     `stakepooluserinfo`       | `"user"`
     `sweepaccount`            | `"sourceaccount"` `"destinationaddress"` (`requiredconfirmations` `feeperkb`)
+    `syncstatus`              |
     `ticketinfo`              | (`startheight=0`)
     `ticketsforaddress`       | `"address"`
-    `treasurypolicy`          | (`"key"`)
-    `tspendpolicy`            | (`"hash"`)
+    `treasurypolicy`          | (`"key"` `"ticket"`)
+    `tspendpolicy`            | (`"hash"` `"ticket"`)
     `unlockaccount`           | `"account"` `"passphrase"`
     `validateaddress`         | `"address"`
     `validatepredcp0005cf`    |

--- a/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
+++ b/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
@@ -16,13 +16,14 @@ dcrd --logdir=/my/custom/log/directory
 ## `dcrd`
 
 ??? info "Click to expand full list of `dcrd` CLI arguments"
-    Argument                          |Description
+    General                           |Description
     ----------------------------------|-------------
     `-V` or `--version`               | Display version information and exit
     `-A` or `--appdata=`              | Path to application home directory (default: `~/.dcrd`)
     `-C` or `--configfile=`           | Path to configuration file (default: `~/.dcrd/dcrd.conf`)
     `-b` or `--datadir=`              | Directory to store data (default: `~/.dcrd/data`)
-            `--logdir=`               | Directory to log output. (default: `~/.dcrd/logs`)
+            `--logdir=`               | Directory to log output (default: `~/.dcrd/logs`)
+            `--logsize=`              | Maximum size of log file before it is rotated (default: 10 MiB)
             `--nofilelogging`         | Disable file logging.
             `--dbtype=`               | Database backend to use for the Block Chain (default: ffldb)
             `--profile=`              | Enable HTTP profiling on given [addr:]port -- **NOTE:** port must be between 1024 and 65536
@@ -31,12 +32,18 @@ dcrd --logdir=/my/custom/log/directory
             `--testnet`               | Use the test network
             `--simnet`                | Use the simulation test network
             `--regnet`                | Use the regression test network
-    `-d` or `--debuglevel=`           | Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems (default: info)
+    `-d` or `--debuglevel=`           | Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>`,`<subsystem2>=<level>`,... to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
             `--sigcachemaxsize=`      | The maximum number of entries in the signature verification cache (default: 100000)
+            `--utxocachemaxsize=`     | The maximum size in MiB of the utxo cache (default: 150, min: 25, max: 32768)
+
+    RPC Server                        |Description
+    ----------------------------------|-------------
             `--norpc`                 | Disable built-in RPC server -- **NOTE:** The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified
             `--rpclisten=`            | Add an interface/port to listen for RPC connections (default port: 9109, testnet: 19109)
     `-u` or `--rpcuser=`              | Username for RPC connections
     `-P` or `--rpcpass=`              | Password for RPC connections
+            `--authtype=`             | Method for RPC client authentication (`basic` (default) or `clientcert`)
+            `--clientcafile=`         | File containing Certificate Authorities to verify TLS client certificates; requires authtype=clientcert; (default: `~/.dcrd/clients.pem`)
             `--rpclimituser=`         | Username for limited RPC connections
             `--rpclimitpass=`         | Password for limited RPC connections
             `--rpccert=`              | File containing the certificate file (default: `~/.dcrd/rpc.cert`)
@@ -47,6 +54,9 @@ dcrd --logdir=/my/custom/log/directory
             `--rpcmaxclients=`        | Max number of RPC clients for standard connections (default: 10)
             `--rpcmaxwebsockets=`     | Max number of RPC websocket connections (default: 25)
             `--rpcmaxconcurrentreqs=` | Max number of concurrent RPC requests that may be processed concurrently (default: 20)
+
+    P2P Proxy and Tor                 |Description
+    ----------------------------------|-------------
             `--proxy=`                | Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
             `--proxyuser=`            | Username for proxy server
             `--proxypass=`            | Password for proxy server
@@ -55,6 +65,9 @@ dcrd --logdir=/my/custom/log/directory
             `--onionpass=`            | Password for onion proxy server
             `--noonion`               | Disable connecting to Tor hidden services
             `--torisolation`          | Enable Tor stream isolation by randomizing user credentials for each connection.
+
+    P2P Network                       |Description
+    ----------------------------------|-------------
     `-a` or `--addpeer=`              | Add a peer to connect with at startup
             `--connect=`              | Connect only to the specified peers at startup
             `--nolisten`              | Disable listening for incoming connections -- **NOTE:** Listening is automatically disabled if the `--connect` or `--proxy` options are used without also specifying listen interfaces via `--listen`
@@ -63,25 +76,40 @@ dcrd --logdir=/my/custom/log/directory
             `--maxpeers=`             | Max number of inbound and outbound peers (default: 125)
             `--dialtimeout=`          | How long to wait for TCP connection completion.  Valid time units are {s, m, h}.  Minimum 1 second (default: 30s)
             `--peeridletimeout=`      | The duration of inactivity before a peer is timed out. Valid time units are {s,m,h}. Minimum 15 seconds (default: 2m0s)
+
+    P2P Network Discovery             |Description
+    ----------------------------------|-------------
             `--noseeders`             | Disable seeding for peer discovery
-            `--nodnsseed`             | **DEPRECATED** -- use --noseeders
-            `--externalip=`           | Add an ip to the list of local addresses we claim to listen on to peers
+            `--externalip=`           | Add an IP to the list of local addresses we claim to listen on to peers
             `--nodiscoverip`          | Disable automatic network address discovery of local external IPs
             `--upnp`                  | Use UPnP to map our listening port outside of NAT
+
+    Banning                           |Description
+    ----------------------------------|-------------
             `--nobanning`             | Disable banning of misbehaving peers
             `--banduration=`          | How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second (default: 24h0m0s)
             `--banthreshold=`         | Maximum allowed ban score before disconnecting and banning misbehaving peers. (default: 100)
             `--whitelist=`            | Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)
-            `--nocheckpoints`         | Disable built-in checkpoints.  Don't do this unless you know what you're doing.
+
+    Chain Related                     |Description
+    ----------------------------------|-------------
+            `--nocheckpoints`         | Disable built-in checkpoints. Checkpoints allow a faster initial blockchain download. Don't disable them unless you know what you're doing.
             `--dumpblockchain=`       | Write blockchain as a flat file of blocks for use with addblock, to the specified filename
+            `--assumevalid=`            | Hash of an assumed valid block.  Defaults to the hard-coded assumed valid block that is updated periodically with new releases.  Don't use a different hash unless you understand the implications.  Set to 0 to disable
+
+    Relay and Mempool Policy          |Description
+    ----------------------------------|-------------
             `--minrelaytxfee=`        | The minimum transaction fee in DCR/kB to be considered a non-zero fee. (default: 0.0001)
             `--limitfreerelay=`       | Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute (default: 15)
             `--norelaypriority`       | Do not require free or low-fee transactions to have high priority for relaying
             `--maxorphantx=`          | Max number of orphan transactions to keep in memory (default: 100)
             `--blocksonly`            | Do not accept transactions from remote peers.
-            `--acceptnonstd`          | Accept and relay non-standard transactions to the network regardless of the default settings for the active network.
-            `--rejectnonstd`          | Reject non-standard transactions regardless of the default settings for the active network.
+            `--acceptnonstd`          | Accept and relay non-standard transactions to the network regardless of the default settings for the active network. (This is not the default for mainnet)
+            `--rejectnonstd`          | Reject non-standard transactions regardless of the default settings for the active network. (This is the default for mainnet)
             `--allowoldvotes`         | Enable the addition of very old votes to the mempool
+
+    Mining Options and Policy         |Description
+    ----------------------------------|-------------
             `--generate`              | Generate (mine) coins using the CPU
             `--miningaddr=`           | Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set
             `--blockminsize=`         | Minimum block size in bytes to be used when creating a block
@@ -91,14 +119,18 @@ dcrd --logdir=/my/custom/log/directory
             `--nonaggressive`         | Disable mining off of the parent block of the blockchain if there aren't enough voters
             `--nominingstatesync`     | Disable synchronizing the mining state with other nodes
             `--allowunsyncedmining`   | Allow block templates to be generated even when the chain is not considered synced on networks other than the main network.  This is automatically enabled when the simnet option is set.  Don't do this unless you know what you're doing
+
+    Indexing                          |Description
+    ----------------------------------|-------------
             `--txindex`               | Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC
             `--droptxindex`           | Deletes the hash-based transaction index from the database on startup and then exits.
             `--addrindex`             | Maintain a full address-based transaction index which makes the searchrawtransactions RPC available
             `--dropaddrindex`         | Deletes the address-based transaction index from the database on startup and then exits.
             `--noexistsaddrindex`     | Disable the exists address index, which tracks whether or not an address has even been used.
             `--dropexistsaddrindex`   | Deletes the exists address index from the database on startup and then exits.
-            `--nocfilters`            | **DEPRECATED** -- Disable compact filtering (CF) support
-            `--dropcfindex`           | **DEPRECATED** -- Deletes the index used for compact filtering (CF) support from the database on startup and then exits.
+
+    IPC (Interprocess Communication)  |Description
+    ----------------------------------|-------------
             `--piperx=`               | File descriptor of read end pipe to enable parent -> child process communication
             `--pipetx=`               | File descriptor of write end pipe to enable parent <- child process communication
             `--lifetimeevents`        | Send lifetime notifications over the TX pipe
@@ -108,7 +140,7 @@ dcrd --logdir=/my/custom/log/directory
 ## `dcrwallet`
 
 ??? info "Click to expand full list of `dcrwallet` CLI arguments"
-    Argument                                           |Description
+    General                                            |Description
     ---------------------------------------------------|-------------
     `-C` or `--configfile=`                            | Path to configuration file (default: `~/.dcrwallet/dcrwallet.conf`)
     `-V` or `--version`                                | Display version information and exit
@@ -119,10 +151,13 @@ dcrd --logdir=/my/custom/log/directory
             `--testnet`                                | Use the test network
             `--simnet`                                 | Use the simulation test network
             `--noinitialload`                          | Defer wallet creation/opening on startup and enable loading wallets over RPC
-    `-d` or `--debuglevel=`                            | Logging level {trace, debug, info, warn, error, critical} (default: info)
+    `-d` or `--debuglevel=`                            | Logging level {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>`,`<subsystem2>=<level>`,... to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
             `--logdir=`                                | Directory to log output. (default: `~/.dcrwallet/logs`)
             `--profile=`                               | Enable HTTP profiling this interface/port
             `--memprofile=`                            | Write mem profile to the specified file
+
+    Wallet                                             |Description
+    ---------------------------------------------------|-------------
             `--walletpass=`                            | The public wallet password -- Only required if the wallet was created with one
             `--promptpass`                             | The private wallet password is prompted for at start up, so the wallet starts unlocked without a time limit
             `--pass=`                                  | The private wallet passphrase
@@ -135,26 +170,38 @@ dcrd --logdir=/my/custom/log/directory
             `--gaplimit=`                              | The size of gaps between used addresses.  Used for address scanning and when generating addresses with the wrap option. (default: 20)
             `--stakepoolcoldextkey=`                   | Enables the wallet as a stake pool with an extended key in the format of "xpub...:index" to derive cold wallet addresses to send fees to
             `--manualtickets`                          | Do not discover new tickets through network synchronization
-            `--allowhighfees`                          | Force the RPC client to use the 'allowHighFees' flag when sending transactions
-            `--txfee=`                                 | Sets the wallet's tx fee per kb (default: 0.0001 DCR)
+            `--allowhighfees`                          | Allows the wallet to send transactions with very large fees. By default, this is any fee over 0.1 DCR/kB
+            `--txfee=`                                 | Sets the transaction fee in DCR/kB that this wallet will pay to miners (default: 0.0001)
             `--accountgaplimit=`                       | Number of accounts that can be created in a row without using any of them (default: 10)
             `--disablecointypeupgrades`                | Never upgrade from legacy to SLIP0044 coin type keys
+
+    RPC Client                                         |Description
+    ---------------------------------------------------|-------------
     `-c` or `--rpcconnect=`                            | Hostname/IP and port of dcrd RPC server to connect to
-            `--cafile=`                                | File containing root certificates to authenticate a TLS connections with dcrd
+            `--cafile=`                                | File containing root certificates to authenticate a TLS connection with dcrd
             `--clientcafile=`                          | Certficate Authority to verify TLS client certificates (default: `~/.dcrwallet/clients.pem`)
             `--noclienttls`                            | Disable TLS for the RPC client -- **NOTE:** This is only allowed if the RPC client is connecting to localhost
             `--dcrdusername=`                          | Username for dcrd authentication
             `--dcrdpassword=`                          | Password for dcrd authentication
+
+    P2P Proxy and Tor                                  |Description
+    ---------------------------------------------------|-------------
             `--proxy=`                                 | Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
             `--proxyuser=`                             | Username for proxy server
             `--proxypass=`                             | Password for proxy server
             `--circuitlimit=`                          | Set maximum number of open Tor circuits; used only when `--torisolation` is enabled (default: 32)
             `--torisolation`                           | Enable Tor stream isolation by randomizing user credentials for each connection
             `--nodcrdproxy`                            | Never use configured proxy to dial dcrd websocket connectons
+
+    SPV                                                |Description
+    ---------------------------------------------------|-------------
             `--spv`                                    | Sync using simplified payment verification
-            `--spvconnect=`                            | Full node addresses to SPV sync from
-            `--rpccert=`                               | File containing the certificate file (default: `~/.dcrwallet/rpc.cert`)
-            `--rpckey=`                                | File containing the certificate key (default: `~/.dcrwallet/rpc.key`)
+            `--spvconnect=`                            | Full node addresses to SPV sync from; disables DNS seeding
+
+    RPC Server                                         |Description
+    ---------------------------------------------------|-------------
+            `--rpccert=`                               | File containing the TLS certificate (default: `~/.dcrwallet/rpc.cert`)
+            `--rpckey=`                                | File containing the TLS key (default: `~/.dcrwallet/rpc.key`)
             `--tlscurve=`                              | Curve to use when generating TLS keypairs (default: P-521)
             `--onetimetlskey`                          | Generate a new TLS certpair at startup, but only write the certificate to disk
             `--noservertls`                            | Disable TLS for the RPC servers -- **NOTE:** This is only allowed if the RPC server is bound to localhost
@@ -167,20 +214,33 @@ dcrd --logdir=/my/custom/log/directory
     `-u` or `--username=`                              | Username for legacy JSON-RPC and dcrd authentication (if dcrdusername is unset)
     `-P` or `--password=`                              | Password for legacy JSON-RPC and dcrd authentication (if dcrdpassword is unset)
             `--jsonrpcauthtype=`                       | Method for JSON-RPC client authentication (basic or clientcert) (default: basic)
+
+    IPC (Interprocess Communication)                   |Description
+    ---------------------------------------------------|-------------
             `--pipetx=`                                | File descriptor or handle of write end pipe to enable child -> parent process communication
             `--piperx=`                                | File descriptor or handle of read end pipe to enable parent -> child process communication
             `--rpclistenerevents`                      | Notify JSON-RPC and gRPC listener addresses over the TX pipe
             `--issueclientcert`                        | Notify a client cert and key over the TX pipe for RPC authentication
+
+    Mixing (CSPP)                                      |Description
+    ---------------------------------------------------|-------------
             `--csppserver=`                            | Network address of CoinShuffle++ server
             `--csppserver.ca=`                         | CoinShuffle++ Certificate Authority
             `--mixedaccount=`                          | Account/branch used to derive CoinShuffle++ mixed outputs and voting rewards
             `--ticketsplitaccount=`                    | Account to derive fresh addresses from for mixed ticket splits; uses mixedaccount if unset
             `--changeaccount=`                         | Account used to derive unmixed CoinJoin outputs in CoinShuffle++ protocol
             `--mixchange`                              | Use CoinShuffle++ to mix change account outputs into mix account
+            `--mixsplitlimit=`                         | Connection limit to CoinShuffle++ server per change amount
+
+    Auto Ticketbuyer                                   |Description
+    ---------------------------------------------------|-------------
             `--ticketbuyer.balancetomaintainabsolute=` | Amount of funds to keep in wallet when stake mining (default: 0 DCR)
             `--ticketbuyer.votingaddress=`             | Purchase tickets with voting rights assigned to this address
             `--ticketbuyer.limit=`                     | Buy no more than specified number of tickets per block (0 disables limit)
             `--ticketbuyer.votingaccount=`             | Account used to derive addresses specifying voting rights
+
+    VSP Options                                        |Description
+    ---------------------------------------------------|-------------
             `--vsp.url=`                               | Base URL of the VSP server
             `--vsp.pubkey=`                            | VSP server pubkey
             `--vsp.sync`                               | sync tickets to vsp

--- a/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
+++ b/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
@@ -80,7 +80,7 @@ dcrd --logdir=/my/custom/log/directory
     P2P Network Discovery             |Description
     ----------------------------------|-------------
             `--noseeders`             | Disable seeding for peer discovery
-            `--externalip=`           | Add an IP to the list of local addresses we claim to listen on to peers
+            `--externalip=`           | Add a public-facing IP to the list of local external IPs that dcrd will advertise to other peers
             `--nodiscoverip`          | Disable automatic network address discovery of local external IPs
             `--upnp`                  | Use UPnP to map our listening port outside of NAT
 
@@ -165,15 +165,13 @@ dcrd --logdir=/my/custom/log/directory
             `--enableticketbuyer`                      | Enable the automatic ticket buyer
             `--enablevoting`                           | Enable creation of votes and revocations for owned tickets
             `--purchaseaccount=`                       | Name of the account to buy tickets from (default: default)
-            `--pooladdress=`                           | The ticket pool address where ticket fees will go to
-            `--poolfees=`                              | The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)
             `--gaplimit=`                              | The size of gaps between used addresses.  Used for address scanning and when generating addresses with the wrap option. (default: 20)
-            `--stakepoolcoldextkey=`                   | Enables the wallet as a stake pool with an extended key in the format of "xpub...:index" to derive cold wallet addresses to send fees to
-            `--manualtickets`                          | Do not discover new tickets through network synchronization
             `--allowhighfees`                          | Allows the wallet to send transactions with very large fees. By default, this is any fee over 0.1 DCR/kB
             `--txfee=`                                 | Sets the transaction fee in DCR/kB that this wallet will pay to miners (default: 0.0001)
             `--accountgaplimit=`                       | Number of accounts that can be created in a row without using any of them (default: 10)
             `--disablecointypeupgrades`                | Never upgrade from legacy to SLIP0044 coin type keys
+            `--pooladdress=`                           | **DEPRECATED: This field was for legacy Stakepools, which have been replaced by Voting Service Providers (VSPs).** The ticket pool address where ticket fees will go to
+            `--poolfees=`                              | **DEPRECATED: This field was for legacy Stakepools, which have been replaced by Voting Service Providers (VSPs).** The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)
 
     RPC Client                                         |Description
     ---------------------------------------------------|-------------
@@ -245,3 +243,5 @@ dcrd --logdir=/my/custom/log/directory
             `--vsp.pubkey=`                            | VSP server pubkey
             `--vsp.sync`                               | sync tickets to vsp
             `--vsp.maxfee=`                            | Maximum VSP fee (default: 0.1 DCR)
+            `--stakepoolcoldextkey=`                   | **VSP Admins Only:** Enables the wallet as a stake pool with an extended key in the format of "xpub...:index" to derive cold wallet addresses to send fees to
+            `--manualtickets`                          | **VSP Admins Only:** Do not discover new tickets through network synchronization

--- a/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
+++ b/docs/wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
@@ -32,7 +32,7 @@ dcrd --logdir=/my/custom/log/directory
             `--testnet`               | Use the test network
             `--simnet`                | Use the simulation test network
             `--regnet`                | Use the regression test network
-    `-d` or `--debuglevel=`           | Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>`,`<subsystem2>=<level>`,... to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
+    `-d` or `--debuglevel=`           | Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>,<subsystem2>=<level>,...` to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
             `--sigcachemaxsize=`      | The maximum number of entries in the signature verification cache (default: 100000)
             `--utxocachemaxsize=`     | The maximum size in MiB of the utxo cache (default: 150, min: 25, max: 32768)
 
@@ -151,7 +151,7 @@ dcrd --logdir=/my/custom/log/directory
             `--testnet`                                | Use the test network
             `--simnet`                                 | Use the simulation test network
             `--noinitialload`                          | Defer wallet creation/opening on startup and enable loading wallets over RPC
-    `-d` or `--debuglevel=`                            | Logging level {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>`,`<subsystem2>=<level>`,... to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
+    `-d` or `--debuglevel=`                            | Logging level {trace, debug, info, warn, error, critical} -- You may also specify `<subsystem>=<level>,<subsystem2>=<level>,...` to set the log level for individual subsystems -- Use `show` to list available subsystems (default: info)
             `--logdir=`                                | Directory to log output. (default: `~/.dcrwallet/logs`)
             `--profile=`                               | Enable HTTP profiling this interface/port
             `--memprofile=`                            | Write mem profile to the specified file
@@ -172,6 +172,7 @@ dcrd --logdir=/my/custom/log/directory
             `--disablecointypeupgrades`                | Never upgrade from legacy to SLIP0044 coin type keys
             `--pooladdress=`                           | **DEPRECATED: This field was for legacy Stakepools, which have been replaced by Voting Service Providers (VSPs).** The ticket pool address where ticket fees will go to
             `--poolfees=`                              | **DEPRECATED: This field was for legacy Stakepools, which have been replaced by Voting Service Providers (VSPs).** The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)
+            `--stakepoolcoldextkey=`                   | **DEPRECATED: This field was for legacy Stakepools, which have been replaced by Voting Service Providers (VSPs).** Enables the wallet as a stake pool with an extended key in the format of "xpub...:index" to derive cold wallet addresses to send fees to
 
     RPC Client                                         |Description
     ---------------------------------------------------|-------------
@@ -243,5 +244,4 @@ dcrd --logdir=/my/custom/log/directory
             `--vsp.pubkey=`                            | VSP server pubkey
             `--vsp.sync`                               | sync tickets to vsp
             `--vsp.maxfee=`                            | Maximum VSP fee (default: 0.1 DCR)
-            `--stakepoolcoldextkey=`                   | **VSP Admins Only:** Enables the wallet as a stake pool with an extended key in the format of "xpub...:index" to derive cold wallet addresses to send fees to
             `--manualtickets`                          | **VSP Admins Only:** Do not discover new tickets through network synchronization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ theme:
         name: Switch to light mode
 extra:
   decreditonversion: 1.6.3
-  cliversion: 1.7.1
+  cliversion: 1.7.2
   lndversion: 0.3.0
   social:
     - icon: octicons/mark-github-16

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ theme:
         name: Switch to light mode
 extra:
   decreditonversion: 1.6.3
-  cliversion: 1.6.3
+  cliversion: 1.7.1
   lndversion: 0.3.0
   social:
     - icon: octicons/mark-github-16
@@ -259,4 +259,4 @@ nav:
 - 'Glossary': 'glossary.md'
 - About:
     - 'License': 'about/license.md'
-copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new">open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare">send a pull request</a>.<br />dcrdocs v0.0.3. Decred Project 2016-2021.
+copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new">open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare">send a pull request</a>.<br />dcrdocs v0.0.3. Decred Project 2016-2022.


### PR DESCRIPTION
Files reviewed so far:
* advanced/manual-cli-install.md
    * Added file for Apple M1 chip
    * Added BSD. Could be useful for SEO in addition to suggesting a highly secure OS
* wallets/cli/dcrd-and-dcrwallet-cli-arguments.md
    * Split apart the arguments tables into more-easy-to-read categories, just following what was done in the `config.go` sections of both dcrd and dcrwallet.
    * Added some missing commands, which exist in dcrd
    * Fixed minor typos or added minor clarifying text.