### PR TITLE
Using the Block Explorer: Update & Reorganize

### DIFF
--- a/docs/getting-started/using-the-block-explorer.md
+++ b/docs/getting-started/using-the-block-explorer.md
@@ -4,60 +4,67 @@
 
 ## ![](../img/dcr-icons/Info.svg){ .dcr-icon } Overview
 
-All blocks and transactions on the Decred blockchain
-are visible through the use of the block explorer, [dcrdata](https://github.com/decred/dcrdata).
+All blocks and transactions on the Decred blockchain are visible through the
+use of the block explorer, [dcrdata](https://github.com/decred/dcrdata).
 
 Public instances of dcrdata are available for the following networks:
 
 - [mainnet](https://dcrdata.decred.org)
 - [testnet](https://testnet.decred.org)
 
-Below is a quick review of some of the information on them.
-
-Option         | Explanation
----            | ---
-`Height`       | The block number.
-`Age`          | How long ago the block was added to the blockchain.
-`Transactions` | The number of transactions included in the block.
-`Votes`        | The number of proof-of-stake votes included in the block.
-`Fresh Stake`  | The number of new tickets purchased in this block.
-`Size`         | The size (in bytes) of the block.
-
-Under `Latest Transactions`, you can see the transaction ID (txid) and
-the value (in DCR) transmitted across the network.
-
 ---
 
 ## ![](../img/dcr-icons/Blocks.svg){ .dcr-icon } Blocks
 
-Blocks can be found by searching for their block height number,
-clicking on a `Height` value from the home page, or from their
-`BlockHash` value. Older blocks will have lower block numbers. The top
-half of a block overview shows relevant information about this
-specific block. This information includes: the block height, the block
-hash, and several key network parameters, described below:
+Blocks can be found by searching for their block height number, clicking on a
+`Height` value from the home page, or from their `BlockHash` value. Older
+blocks will have lower block numbers.
 
-Option                   | Explanation
+Each block is packed with information. There are two main sections inside a
+block: 
+
+1. **The Block Header**
+    - This shows summary information about this specific block, as well as a
+    link to the previous block in the chain.
+2. **Transactions**
+    - Consisting of:
+        - The Proof-of-Work Reward
+        - The Treasury Reward
+        - Proof-of-Stake Votes and Rewards
+        - Tickets which will enter the stakepool
+        - All other transactions about how DCR is transmitted across the network
+
+---
+
+## Block Headers
+
+The following table should help explain what you'll see in the top section of
+[dcrdata](https://dcrdata.decred.org). This is generally all information that's
+also found inside a block header, although it adds some additional context.
+
+Parameter                | Explanation
 ---                      | ---
-`Number of Transactions` | The number of standard transactions (DCR sent from one user to another).
+`Block Hash`             | The unique hash of this specific block, which was found by the miner.
+`Confirmations`          | The number of new blocks which follow this block in the chain.
+`Size`                   | The size of the block (in bytes).
 `Height`                 | The height of the blockchain in which this block resides.
-`Block Reward`           | The amount of new DCR minted in this block.
-`Timestamp`              | The time this block was created by a miner and was included in the blockchain.
+`Version`                | The version of the block header.
 `Merkle Root`            | A hash value of all the transaction hashes and stake hashes (ticket purchases, votes, and revocations) included in this block.
 `Stake Root`             | Originally, this was a hash value of all the stake related transaction hashes in this block. However, as of [DCP-0005](https://github.com/decred/dcps/blob/master/dcp-0005/dcp-0005.mediawiki), the stake hashes were moved into the Merkle Root, and the Stake Root was repurposed to house header commitments. These includes additional proofs and compact filters, which enable a more secure SPV mode for lightweight clients.
+`Number of Transactions` | The number of standard transactions (DCR sent from one user to another).
+`Block Reward`           | The amount of new DCR minted in this block.
+`Time`                   | The time this block was created by a miner and was included in the blockchain.
+`Nonce`                  | The value used by a miner to find a valid solution for this block.
 `VoteBits`               | Used to signify the voting result on the previous block. This will either be 0 or 1. If 1, the previous block was approved by proof-of-stake voters. If 0, the previous block was disapproved by proof-of-stake voters and all non-stake transactions in the block were invalidated, including the newly generated block reward for the proof-of-work miner and the Decred Treasury.
 `Final State`            | The hash value of the final state of the lottery used to determine which tickets were eligible to vote on the previous block, and thus be included in this block. It consists of the five winning ticket hashes, as well as the state of the pseudorandom number generator that was used to select those winning tickets from the live tickets pool.
 `Voters`                 | The number of successful proof-of-stake votes cast in this block. The maximum value is 5. Tickets can fail to vote when called upon, but a minimum of 3 votes are required.
-`Fresh Stake`            | The number of stake ticket purchases confirmed in this block.
+`Fresh Stake`            | The number of stake ticket purchases in this block, which will be added to the ticket pool.
 `Revocations`            | The number of tickets that failed to vote and were revoked.
 `PoolSize`               | The total number of active proof-of-stake tickets.
-`Difficulty`             | The proof-of-work network difficulty.
-`SBits`                  | The price of one proof-of-stake ticket.
 `Bits`                   | A compact version of the network difficulty at the time the block was mined.
-`Size`                   | The size of the block (in bytes).
-`Version`     		 | The version of the block header.
+`SBits`                  | The price of one proof-of-stake ticket.
 `Stake Version`          | The stake version used for voting on the created block.
-`Nonce`                  | The value used by a miner to find a valid solution for this block.
+`Difficulty`             | The proof-of-work network difficulty.
 
 For a more advanced description of block headers, see the Dev Docs on [Block Header Specifications](https://devdocs.decred.org/developer-guides/block-header-specifications/).
 

--- a/docs/getting-started/using-the-block-explorer.md
+++ b/docs/getting-started/using-the-block-explorer.md
@@ -43,11 +43,11 @@ Option                   | Explanation
 `Height`                 | The height of the blockchain in which this block resides.
 `Block Reward`           | The amount of new DCR minted in this block.
 `Timestamp`              | The time this block was created by a miner and was included in the blockchain.
-`Merkle Root`            | A hash value of all the transaction hashes included in this block.
-`Stake Root`             | A hash value of all the stake related transaction hashes in this block. This includes ticket purchases, votes, and ticket revocations.
-`VoteBits`               | (1) Block was approved by proof-of-stake voters. (2) Block was vetoed by proof-of-stake voters and all non-stake transactions in the block were invalidated, along with the newly generated block reward for the proof-of-work miner and the Decred Treasury.
-`Final State`            | The final state of the pseudo random number generator used for ticket selection.
-`Voters`                 | The number of successful proof-of-stake votes cast in this block. The maximum value is 5.
+`Merkle Root`            | A hash value of all the transaction hashes and stake hashes (ticket purchases, votes, and revocations) included in this block.
+`Stake Root`             | Originally, this was a hash value of all the stake related transaction hashes in this block. However, as of [DCP-0005](https://github.com/decred/dcps/blob/master/dcp-0005/dcp-0005.mediawiki), the stake hashes were moved into the Merkle Root, and the Stake Root was repurposed to house header commitments. These includes additional proofs and compact filters, which enable a more secure SPV mode for lightweight clients.
+`VoteBits`               | Used to signify the voting result on the previous block. This will either be 0 or 1. If 1, the previous block was approved by proof-of-stake voters. If 0, the previous block was disapproved by proof-of-stake voters and all non-stake transactions in the block were invalidated, including the newly generated block reward for the proof-of-work miner and the Decred Treasury.
+`Final State`            | The hash value of the final state of the lottery used to determine which tickets were eligible to vote on the previous block, and thus be included in this block. It consists of the five winning ticket hashes, as well as the state of the pseudorandom number generator that was used to select those winning tickets from the live tickets pool.
+`Voters`                 | The number of successful proof-of-stake votes cast in this block. The maximum value is 5. Tickets can fail to vote when called upon, but a minimum of 3 votes are required.
 `Fresh Stake`            | The number of stake ticket purchases confirmed in this block.
 `Revocations`            | The number of tickets that failed to vote and were revoked.
 `PoolSize`               | The total number of active proof-of-stake tickets.
@@ -55,8 +55,11 @@ Option                   | Explanation
 `SBits`                  | The price of one proof-of-stake ticket.
 `Bits`                   | A compact version of the network difficulty at the time the block was mined.
 `Size`                   | The size of the block (in bytes).
-`Version`                | The version of the block.
-`Nonce`                  | The value used by a miner to find the correct solution for this block.
+`Version`     		 | The version of the block header.
+`Stake Version`          | The stake version used for voting on the created block.
+`Nonce`                  | The value used by a miner to find a valid solution for this block.
+
+For a more advanced description of block headers, see the Dev Docs on [Block Header Specifications](https://devdocs.decred.org/developer-guides/block-header-specifications/).
 
 ## ![](../img/dcr-icons/Transactions.svg){ .dcr-icon } Transactions
 

--- a/docs/getting-started/using-the-block-explorer.md
+++ b/docs/getting-started/using-the-block-explorer.md
@@ -28,11 +28,11 @@ block:
     link to the previous block in the chain.
 2. **Transactions**
     - Consisting of:
-        - The Proof-of-Work Reward
-        - The Treasury Reward
-        - Proof-of-Stake Votes and Rewards
-        - Tickets which will enter the stakepool
-        - All other transactions about how DCR is transmitted across the network
+        - The Proof-of-Work reward
+        - The Treasury reward
+        - Proof-of-Stake votes and rewards
+        - Proof-of-Stake ticket purchases
+        - All other regular transactions which transmit DCR across the network
 
 ---
 
@@ -42,16 +42,18 @@ The following table should help explain what you'll see in the top section of
 [dcrdata](https://dcrdata.decred.org). This is generally all information that's
 also found inside a block header, although it adds some additional context.
 
-Parameter                | Explanation
+For a more advanced description of block headers, see the Dev Docs on [Block Header Specifications](https://devdocs.decred.org/developer-guides/block-header-specifications/).
+
+Value                    | Explanation
 ---                      | ---
 `Block Hash`             | The unique hash of this specific block, which was found by the miner.
 `Confirmations`          | The number of new blocks which follow this block in the chain.
-`Size`                   | The size of the block (in bytes).
+`Size`                   | The size of the block (in kB).
 `Height`                 | The height of the blockchain in which this block resides.
 `Version`                | The version of the block header.
 `Merkle Root`            | A hash value of all the transaction hashes and stake hashes (ticket purchases, votes, and revocations) included in this block.
 `Stake Root`             | Originally, this was a hash value of all the stake related transaction hashes in this block. However, as of [DCP-0005](https://github.com/decred/dcps/blob/master/dcp-0005/dcp-0005.mediawiki), the stake hashes were moved into the Merkle Root, and the Stake Root was repurposed to house header commitments. These includes additional proofs and compact filters, which enable a more secure SPV mode for lightweight clients.
-`Number of Transactions` | The number of standard transactions (DCR sent from one user to another).
+`Number of Transactions` | The number of regular transactions (DCR sent from one user to another).
 `Block Reward`           | The amount of new DCR minted in this block.
 `Time`                   | The time this block was created by a miner and was included in the blockchain.
 `Nonce`                  | The value used by a miner to find a valid solution for this block.
@@ -65,8 +67,6 @@ Parameter                | Explanation
 `SBits`                  | The price of one proof-of-stake ticket.
 `Stake Version`          | The stake version used for voting on the created block.
 `Difficulty`             | The proof-of-work network difficulty.
-
-For a more advanced description of block headers, see the Dev Docs on [Block Header Specifications](https://devdocs.decred.org/developer-guides/block-header-specifications/).
 
 ## ![](../img/dcr-icons/Transactions.svg){ .dcr-icon } Transactions
 
@@ -83,7 +83,7 @@ review each type of transaction.
 
 Here’s the information included in standard Decred transactions.
 
-Option              | Explanation
+Value               | Explanation
 ---                 | ---
 `Size`              | The size of the transaction in bytes.
 `Fee rate`          | The rate of fees collected by the network (per kB).


### PR DESCRIPTION
Based on [this reddit thread](https://www.reddit.com/r/decred/comments/uqrdpa/comment/i8su4lb/) from Dave, and noticing that it caused confusion while PhoenixGreen was making an informational video, I decided to update the docs to be more accurate.

The first commit is just to correct the problems that Dave mentioned.

The second commit is to tidy things up a bit, and to reorganize the structure so that it more closely matches the [dcrdata api](https://dcrdata.decred.org/api/block/661673/verbose?indent=true). This organization is a bit subjective, but I felt like the previous structure didn't have any rhyme or reason, so why not just try to follow dcrdata.