### PR TITLE
Fix dark mode only images.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -78,6 +78,16 @@
     --dcrdocs-table-fg-color:        #EDEFF1;
 }
 
+/* Hide images for light mode */
+[data-md-color-scheme="dcrdocs-dark"] img[src$="#only-light"] {
+  display: none;
+}
+
+/* Show images for dark mode */
+[data-md-color-scheme="dcrdocs-dark"] img[src$="#only-dark"] {
+  display: initial;
+}
+
 /* Highlight current page in nav menu */
 .md-nav__link--active {
     font-weight: bold;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==8.2.8
+mkdocs-material==8.3.4
 mkdocs-markdownextradata-plugin==0.2.5


### PR DESCRIPTION
Dark/light only images have been added to mkdocs-material by implementing it in the colour scheme, rather than in the framework itself.
Because we use a custom colour scheme, we need to make a copy of that implementation. Annoying.

This is likely because the framework is not able to auto-detect which colours are light/dark, e.g. given a red scheme and a green scheme, which is which?