### PR TITLE
remove mention of contractors portrait page

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -31,7 +31,7 @@ The people who are best placed to judge whether a new contributor would make a g
 
 At present, this process is informal, but a formal process for granting a Decred Contractor Clearance (DCC) that allows an individual to bill for their work has been [proposed](https://proposals.decred.org/proposals/fa38a3593d9a3f6cb2478a24c25114f5097c572f6dadf24c78bb521ed10992a4) and approved by stakeholders. This process will involve three established contractors in the relevant domain agreeing that a new contributor should be invited to become a contractor. This DCC model will go live once the [contractor management system](https://github.com/decred/contractor-mgmt) is operational.
 
-As part of becoming a paid contractor, you will agree on an hourly rate at which you can bill for your work on the project. Contractors are also eligible for a portrait to be shown on the [contributors page](https://decred.org/contributors/) of decred.org.
+As part of becoming a paid contractor, you will agree on an hourly rate at which you can bill for your work on the project.
 
 The [Contributor Compensation](contributor-compensation.md) page has details of how billing and payments work.
 


### PR DESCRIPTION
This is a minor cleanup and didn't think it'd be worth creating an issue for.  [Remove contractors page](https://github.com/decred/dcrweb/pull/1047) by @jholdstock has been merged on dcrweb. So it seems right to not reference that page as it will be a 404 error.