### PR TITLE
Add /snippets to watched directories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: Decred Documentation
 use_directory_urls: true
+watch:
+  - "docs"
+  - "snippets"
 theme:
   name: material
   favicon: 'img/favicon.ico?v=s3ss'


### PR DESCRIPTION
By default `mkdocs serve` will only watch the `docs/` directory for changes. Adding the snippets dir means that live-reload will work when snippets are changed.
