### PR TITLE
Remove fa-icons.

### DIFF
--- a/docs/mining/overview.md
+++ b/docs/mining/overview.md
@@ -85,7 +85,7 @@ Enter the local network IP address of your miner in the URL bar of any web brows
 
 ##### ![](../img/dcr-icons/Solo.svg){ .dcr-icon } Solo Mining
 
-:fontawesome-solid-exclamation-triangle: **Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of up to 422Ph/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
+**Solo mining is not recommended and is not covered by this documentation!** The Decred network regularly sees a network hash rate of up to 422Ph/s. Solo mining is generally only done by advanced individuals or organized groups with a large cluster of GPUs so it is not addressed here.
 
 
 #### Pool Mining

--- a/docs/proof-of-stake/how-to-stake.md
+++ b/docs/proof-of-stake/how-to-stake.md
@@ -19,7 +19,7 @@ Solo PoS voting is currently only possible using the Decred command line tools. 
 ## ![](../img/dcr-icons/Servers.svg){ .dcr-icon } PoS using a Voting Service Provider (VSP)
 
 A list of Voting Service Providers (VSPs) and statistics is maintained on the
-[:fontawesome-solid-external-link-square-alt: Decred.org website](https://decred.org/vsp/).
+[Decred.org website](https://decred.org/vsp/).
 
 Using a VSP **does not give the VSP access to your funds**. All you are doing is granting voting rights to the VSP.
 

--- a/docs/wallets/cli/dcrd-setup.md
+++ b/docs/wallets/cli/dcrd-setup.md
@@ -19,7 +19,7 @@ or `tmux`.
 
 ---
 
-## :fontawesome-solid-cloud: Connect to the Decred Network
+## Connect to the Decred Network
 
 The first time launching `dcrd`, it will connect to the Decred network and begin downloading the blockchain. To allow `dcrwallet` and `dcrctl` to communicate with `dcrd`, the configuration files must have `rpcuser` and `rpcpass` settings enabled. 
 


### PR DESCRIPTION
The icons don't work at the moment. Removing them completely makes more sense than fixing them because we are only using them in a small number of places which makes them look out of place.