### PR TITLE
Add synxtax highlighting to custom theme.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -23,6 +23,20 @@
     /* Code */
     --md-code-fg-color:              #48566E;
     --md-code-bg-color:              #EDEFF1;
+    /* Code highlighting color shades */
+    --md-code-hl-color:                var(--md-code-fg-color);
+    --md-code-hl-number-color:         hsla(6, 74%, 63%, 1);
+    --md-code-hl-special-color:        hsla(340, 83%, 66%, 1);
+    --md-code-hl-function-color:       hsla(291, 57%, 65%, 1);
+    --md-code-hl-constant-color:       hsla(250, 62%, 70%, 1);
+    --md-code-hl-keyword-color:        hsla(219, 66%, 64%, 1);
+    --md-code-hl-string-color:         hsla(150, 58%, 44%, 1);
+    --md-code-hl-name-color:           var(--md-code-fg-color);
+    --md-code-hl-operator-color:       var(--md-default-fg-color--light);
+    --md-code-hl-punctuation-color:    var(--md-default-fg-color--light);
+    --md-code-hl-comment-color:        var(--md-default-fg-color--light);
+    --md-code-hl-generic-color:        var(--md-default-fg-color--light);
+    --md-code-hl-variable-color:       var(--md-default-fg-color--light);
     /* Admonitions */
     --md-admonition-fg-color:        #48566E;
     --md-admonition-bg-color:        #fff;
@@ -63,6 +77,20 @@
     /* Code */
     --md-code-fg-color:              #99c1e3;
     --md-code-bg-color:              #152042;
+    /* Code highlighting color shades */
+    --md-code-hl-color:                var(--md-code-fg-color);
+    --md-code-hl-number-color:         hsla(6, 74%, 63%, 1);
+    --md-code-hl-special-color:        hsla(340, 83%, 66%, 1);
+    --md-code-hl-function-color:       hsla(291, 57%, 65%, 1);
+    --md-code-hl-constant-color:       hsla(250, 62%, 70%, 1);
+    --md-code-hl-keyword-color:        hsla(219, 66%, 64%, 1);
+    --md-code-hl-string-color:         hsla(150, 58%, 44%, 1);
+    --md-code-hl-name-color:           var(--md-code-fg-color);
+    --md-code-hl-operator-color:       var(--md-default-fg-color--light);
+    --md-code-hl-punctuation-color:    var(--md-default-fg-color--light);
+    --md-code-hl-comment-color:        var(--md-default-fg-color--light);
+    --md-code-hl-generic-color:        var(--md-default-fg-color--light);
+    --md-code-hl-variable-color:       var(--md-default-fg-color--light);
     /* Admonitions */
     --md-admonition-fg-color:        #99c1e3;
     --md-admonition-bg-color:        #223767;


### PR DESCRIPTION
Our custom theme was missing color variables for code syntax highlighting which resulted in some hard to read text, particularly in dark mode.

### Before

![Screenshot from 2023-02-27 15-17-10](https://user-images.githubusercontent.com/6762864/221604466-bce7dab9-1dc2-4104-9b47-aa6b112891e9.png)

### After

![Screenshot from 2023-02-27 15-16-59](https://user-images.githubusercontent.com/6762864/221604460-66c2ded8-ff88-4899-9ebd-3a7a7f348daa.png)
