### PR TITLE
Update font name to "Source Sans 3"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ plugins:
   - search
   - social:
       cards: !ENV [DCRDOCS_CARDS, false]
-      cards_font: 'Source Sans Pro'
+      cards_font: 'Source Sans 3'
       cards_color:
         fill: '#091440'
         text: '#FFFFFF'


### PR DESCRIPTION
Source Sans Pro is now named Source Sans 3. Using the old name in `mkdocs.yml` was causing the build to fail..

https://github.com/adobe-fonts/source-sans/issues/192