### PR TITLE
Update mkdocs-material to 9.5.21.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Build the Docker image
       run: docker build -t decred/dcrdocs:$(date +%s) .
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Build the Docker image
       run: docker build -t decred/dcrdocs:$(date +%s) .
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,9 +9,9 @@ jobs:
         python-version: [3.11]
 
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,9 +9,9 @@ jobs:
         python-version: [3.11]
 
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018-2023 The Decred developers
+Copyright (c) 2018-2024 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -5,7 +5,7 @@ dcrdocs is licensed under the [copyfree](http://copyfree.org) ISC License.
 ---
 
 Copyright © 2013-2015 The btcsuite developers.  
-Copyright © 2015-2023 The Decred developers.
+Copyright © 2015-2024 The Decred developers.
 
 Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,4 +276,4 @@ nav:
 - 'Glossary': 'glossary.md'
 - About:
     - 'License': 'about/license.md'
-copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new">open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare">send a pull request</a>.<br />dcrdocs v0.0.3. Decred Project 2016-2023.
+copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdocs/issues/new">open an issue</a> or <a href="https://github.com/decred/dcrdocs/compare">send a pull request</a>.<br />dcrdocs v0.0.3. Decred Project 2016-2024.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,8 @@ markdown_extensions:
   - pymdownx.tilde
   - pymdownx.caret
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.superfences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.5.3
+mkdocs-material==9.5.21
 mkdocs-markdownextradata-plugin==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.2.6
+mkdocs-material==9.5.3
 mkdocs-markdownextradata-plugin==0.2.5


### PR DESCRIPTION
Includes lots of minor bug fixes, a smaller docker image, faster build times, and using a new emoji extension.