### PR TITLE
docker: Add -y to apt install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install mkdocs && \
 # Install dependencies for generating social cards.
 # https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards
 RUN apt update && \
-    apt install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev && \
+    apt install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev && \
 	pip install pillow cairosvg
 
 ENV DCRDOCS_CARDS true


### PR DESCRIPTION
This will automatically accept any questions asked by apt and prevent the build from failing.